### PR TITLE
feat: shinigami bridge

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,12 +26,8 @@ jobs:
       - name: Run cargo fmt
         run: cargo fmt --all --check
 
-  cross-testing:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-
-    runs-on: ${{ matrix.os }}
+  build-default:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -50,11 +46,7 @@ jobs:
         run: cargo build --verbose
 
   build-shigami:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,21 +77,3 @@ jobs:
         env:
           PWD: ${{ github.workspace }} # without it ci can't see env!("PWD")
 
-
-  build-docker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-docker-${{ hashFiles('Dockerfile') }}
-
-      - name: Build Docker image
-        run: |
-          docker buildx build --cache-to=type=local,dest=/tmp/.buildx-cache --cache-from=type=local,src=/tmp/.buildx-cache -t dlsz/bridge:latest .

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,97 @@
+name: Rust
+
+on:
+  push:
+  pull_request:
+    branches: ["master"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  linting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install latest nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo fmt
+        run: cargo fmt --all --check
+
+  cross-testing:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Rust
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build
+        run: cargo build --verbose
+
+  build-shigami:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Rust
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build
+        run: cargo build --no-default-features --features shinigami --verbose
+
+      - name: Run tests
+        run: cargo test --no-default-features --features shinigami --verbose
+        env:
+          PWD: ${{ github.workspace }} # without it ci can't see env!("PWD")
+
+
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-docker-${{ hashFiles('Dockerfile') }}
+
+      - name: Build Docker image
+        run: |
+          docker buildx build --cache-to=type=local,dest=/tmp/.buildx-cache --cache-from=type=local,src=/tmp/.buildx-cache -t dlsz/bridge:latest .

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,13 +4,14 @@ version = 3
 
 [[package]]
 name = "actix"
-version = "0.13.0"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f728064aca1c318585bf4bb04ffcfac9e75e508ab4e8b1bd9ba5dfe04e2cbed5"
+checksum = "de7fa236829ba0841304542f7614c42b80fca007455315c45c785ccfa873a85b"
 dependencies = [
+ "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags",
+ "bitflags 2.6.0",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -19,7 +20,7 @@ dependencies = [
  "futures-util",
  "log",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -28,11 +29,11 @@ dependencies = [
 
 [[package]]
 name = "actix-codec"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617a8268e3537fe1d8c9ead925fca49ef6400927ee7bc26750e90ecee14ce4b8"
+checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -45,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "actix-cors"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b340e9cfa5b08690aae90fb61beb44e9b06f44fe3d0f93781aaa58cfba86245e"
+checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
 dependencies = [
  "actix-utils",
  "actix-web",
@@ -60,16 +61,15 @@ dependencies = [
 
 [[package]]
 name = "actix-files"
-version = "0.6.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d832782fac6ca7369a70c9ee9a20554623c5e51c76e190ad151780ebea1cf689"
+checksum = "0773d59061dedb49a8aed04c67291b9d8cf2fe0b60130a381aab53c6dd86e9be"
 dependencies = [
  "actix-http",
  "actix-service",
  "actix-utils",
  "actix-web",
- "askama_escape",
- "bitflags",
+ "bitflags 2.6.0",
  "bytes",
  "derive_more",
  "futures-core",
@@ -79,21 +79,22 @@ dependencies = [
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
+ "v_htmlescape",
 ]
 
 [[package]]
 name = "actix-http"
-version = "3.3.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2079246596c18b4a33e274ae10c0e50613f4d32a4198e09c7b93771013fed74"
+checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "ahash 0.8.3",
- "base64 0.21.2",
- "bitflags",
+ "ahash",
+ "base64 0.22.1",
+ "bitflags 2.6.0",
  "brotli",
  "bytes",
  "bytestring",
@@ -127,27 +128,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.79",
+ "syn",
 ]
 
 [[package]]
 name = "actix-router"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66ff4d247d2b160861fa2866457e85706833527840e4133f8f49aa423a38799"
+checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
+ "cfg-if",
  "http",
  "regex",
+ "regex-lite",
  "serde",
  "tracing",
 ]
 
 [[package]]
 name = "actix-rt"
-version = "2.8.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15265b6b8e2347670eb363c47fc8c75208b4a4994b27192f345fcbe707804f3e"
+checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
  "actix-macros",
  "futures-core",
@@ -156,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e8613a75dd50cc45f473cee3c34d59ed677c0f7b44480ce3b8247d7dc519327"
+checksum = "7ca2549781d8dd6d75c40cf6b6051260a2cc2f3c62343d761a969a0640646894"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -166,7 +169,6 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "num_cpus",
  "socket2",
  "tokio",
  "tracing",
@@ -212,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.3.1"
+version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3cb42f9566ab176e1ef0b8b3a896529062b4efc6be0123046095914c4c1c96"
+checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -225,7 +227,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.7.6",
+ "ahash",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -234,7 +236,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http",
+ "impl-more",
  "itoa",
  "language-tags",
  "log",
@@ -242,6 +244,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "regex",
+ "regex-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -253,41 +256,41 @@ dependencies = [
 
 [[package]]
 name = "actix-web-codegen"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2262160a7ae29e3415554a3f1fc04c764b1540c116aa524683208078b7a75bc9"
+checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
 dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "actix_derive"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d44b8fee1ced9671ba043476deddef739dd0959bf77030b26b738cc591737a7"
+checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aead"
@@ -301,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -312,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",
@@ -326,32 +329,22 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -373,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -388,43 +381,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "arrayvec"
@@ -433,16 +426,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -451,45 +438,45 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.72"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
- "libc 0.2.147",
+ "libc 0.2.161",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -500,9 +487,15 @@ checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-compat"
@@ -586,6 +579,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +603,7 @@ dependencies = [
  "actix-rt",
  "actix-session",
  "actix-web",
+ "ahash",
  "anyhow",
  "async-stream",
  "bitcoin",
@@ -623,13 +623,14 @@ dependencies = [
  "sha2",
  "simplelog",
  "starknet-crypto",
+ "time",
 ]
 
 [[package]]
 name = "brotli"
-version = "3.3.4"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -638,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.4"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -648,38 +649,40 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "bytestring"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238e4886760d98c4f899360c834fa93e62cf7f721ac3c2da375cbdf4b8679aae"
+checksum = "74d80203ea6b29df88012294f62733de21cfeab47f17b41af3a38bc30a03ee72"
 dependencies = [
  "bytes",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
+ "libc 0.2.161",
+ "shlex",
 ]
 
 [[package]]
@@ -729,7 +732,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
 ]
 
 [[package]]
@@ -740,9 +743,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "convert_case"
@@ -769,54 +772,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.8"
+name = "core-foundation"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
- "libc 0.2.147",
+ "core-foundation-sys",
+ "libc 0.2.161",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+dependencies = [
+ "libc 0.2.161",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-bigint"
@@ -851,21 +862,24 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.7"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -881,18 +895,24 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.26"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "flate2"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -906,9 +926,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -919,7 +939,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
- "libc 0.2.147",
+ "libc 0.2.161",
  "winapi",
 ]
 
@@ -931,9 +951,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -946,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -956,15 +976,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -973,38 +993,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1039,20 +1059,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "libc 0.2.147",
+ "libc 0.2.161",
  "wasi",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -1060,15 +1080,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.3.20"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1085,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -1097,9 +1117,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1118,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac",
 ]
@@ -1136,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1147,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",
@@ -1164,21 +1184,21 @@ checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1200,10 +1220,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "rustls",
@@ -1213,21 +1234,27 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.3"
+name = "impl-more"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "aae21c3177a27788957044151cc2800043d127acaa460a47ebb9b84dfa2c6aa0"
+
+[[package]]
+name = "indexmap"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
 ]
 
@@ -1242,18 +1269,18 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.8.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1263,9 +1290,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jemalloc-sys"
@@ -1274,7 +1301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
 dependencies = [
  "cc",
- "libc 0.2.147",
+ "libc 0.2.161",
 ]
 
 [[package]]
@@ -1284,23 +1311,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
 dependencies = [
  "jemalloc-sys",
- "libc 0.2.147",
+ "libc 0.2.161",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
- "libc 0.2.147",
+ "libc 0.2.161",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1375,33 +1402,32 @@ checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "local-channel"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f303ec0e94c6c54447f84f3b0ef7af769858a9c4ef56ef2a986d3dcd4c3fc9c"
+checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
 dependencies = [
  "futures-core",
  "futures-sink",
- "futures-util",
  "local-waker",
 ]
 
 [[package]]
 name = "local-waker"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1409,24 +1435,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1436,9 +1453,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
@@ -1446,23 +1463,24 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "libc 0.2.147",
+ "hermit-abi",
+ "libc 0.2.161",
  "log",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1486,6 +1504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,44 +1528,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc 0.2.147",
-]
-
-[[package]]
 name = "num_threads"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
- "libc 0.2.147",
+ "libc 0.2.161",
 ]
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "parking_lot"
@@ -1556,12 +1570,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.8",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -1572,7 +1586,7 @@ checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if",
  "instant",
- "libc 0.2.147",
+ "libc 0.2.161",
  "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
@@ -1580,34 +1594,34 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
- "libc 0.2.147",
- "redox_syscall 0.3.5",
+ "libc 0.2.161",
+ "redox_syscall 0.5.7",
  "smallvec",
- "windows-targets 0.48.1",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -1617,15 +1631,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polyval"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1634,16 +1648,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
+name = "powerfmt"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1664,7 +1687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc 0.2.147",
+ "libc 0.2.161",
  "rand_core 0.3.1",
  "rdrand",
  "winapi",
@@ -1676,7 +1699,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc 0.2.147",
+ "libc 0.2.161",
  "rand_chacha",
  "rand_core 0.6.4",
 ]
@@ -1730,23 +1753,23 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1756,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1766,10 +1789,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.7.4"
+name = "regex-lite"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remove_dir_all"
@@ -1782,11 +1811,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1808,6 +1837,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1831,39 +1862,39 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
- "libc 0.2.147",
- "once_cell",
+ "cfg-if",
+ "getrandom",
+ "libc 0.2.161",
  "spin",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
@@ -1873,18 +1904,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.7",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.3"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
  "untrusted",
@@ -1901,21 +1932,21 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
@@ -1943,35 +1974,35 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -1993,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2004,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2024,19 +2055,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
- "libc 0.2.147",
+ "libc 0.2.161",
 ]
 
 [[package]]
 name = "simplelog"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
+checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
 dependencies = [
  "log",
  "termcolor",
@@ -2045,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
@@ -2063,32 +2100,32 @@ dependencies = [
  "crossbeam-utils",
  "fs2",
  "fxhash",
- "libc 0.2.147",
+ "libc 0.2.161",
  "log",
  "parking_lot 0.11.2",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
- "libc 0.2.147",
- "winapi",
+ "libc 0.2.161",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "starknet-crypto"
@@ -2140,15 +2177,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2156,14 +2193,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.79"
+name = "sync_wrapper"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc 0.2.161",
 ]
 
 [[package]]
@@ -2178,43 +2231,45 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.25"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
- "libc 0.2.147",
+ "libc 0.2.161",
+ "num-conv",
  "num_threads",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -2222,24 +2277,25 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.11"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2252,21 +2308,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
- "libc 0.2.147",
+ "libc 0.2.161",
  "mio",
- "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2281,16 +2335,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2304,17 +2357,16 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-core",
@@ -2322,51 +2374,48 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -2383,15 +2432,15 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2405,10 +2454,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
+name = "v_htmlescape"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "4e8257fbc510f0a46eb602c10215901938b5c2a7d5e70fc11483b1d3c9b5b18c"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -2427,34 +2482,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2464,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2474,51 +2530,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -2538,11 +2581,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2557,7 +2600,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2570,18 +2613,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.1"
+name = "windows-sys"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2602,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2614,9 +2666,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2626,9 +2678,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2644,9 +2696,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2656,9 +2708,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2668,9 +2720,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2680,9 +2732,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2692,11 +2744,33 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2707,30 +2781,28 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "6.0.6"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
- "libc 0.2.147",
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
- "libc 0.2.147",
  "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.28",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -408,7 +408,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -419,7 +419,7 @@ checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -572,6 +572,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "simplelog",
+ "starknet-crypto",
 ]
 
 [[package]]
@@ -719,6 +720,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -877,7 +889,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1198,6 +1210,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "kv"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1229,28 @@ dependencies = [
  "sled",
  "thiserror",
  "toml",
+]
+
+[[package]]
+name = "lambdaworks-crypto"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc2a4da0d9e52ccfe6306801a112e81a8fc0c76aa3e4449fefeda7fef72bb34"
+dependencies = [
+ "lambdaworks-math",
+ "serde",
+ "sha2",
+ "sha3",
+]
+
+[[package]]
+name = "lambdaworks-math"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1bd2632acbd9957afc5aeec07ad39f078ae38656654043bf16e046fa2730e23"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1322,6 +1365,34 @@ checksum = "0bc85448a6006dd2ba26a385a564a8a0f1f2c7e78c70f1a70b2e0f4af286b823"
 dependencies = [
  "libc 0.1.12",
  "tempdir",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1462,18 +1533,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1641,6 +1712,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,8 +1785,7 @@ dependencies = [
 [[package]]
 name = "rustreexo"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4e6061c2c36ec0f30c8c2e737efc0b69ffc22b57a79a28aefc849c35a1523a"
+source = "git+https://github.com/mit-dci/rustreexo?rev=9d7afec0354c9f37d7e71a7b7e734e4c6dd374da#9d7afec0354c9f37d7e71a7b7e734e4c6dd374da"
 dependencies = [
  "bitcoin_hashes 0.14.0",
  "serde",
@@ -1761,31 +1841,32 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1822,6 +1903,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -1892,6 +1983,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "starknet-crypto"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a5064173a8e8d2675e67744fd07f310de44573924b6b7af225a6bdd8102913"
+dependencies = [
+ "crypto-bigint",
+ "hex",
+ "hmac",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rfc6979",
+ "sha2",
+ "starknet-curve",
+ "starknet-types-core",
+ "zeroize",
+]
+
+[[package]]
+name = "starknet-curve"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcde6bd74269b8161948190ace6cf069ef20ac6e79cd2ba09b320efa7500b6de"
+dependencies = [
+ "starknet-types-core",
+]
+
+[[package]]
+name = "starknet-types-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa1b9e01ccb217ab6d475c5cda05dbb22c30029f7bb52b192a010a00d77a3d74"
+dependencies = [
+ "lambdaworks-crypto",
+ "lambdaworks-math",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1955,7 +2088,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2193,7 +2326,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -2227,7 +2360,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2372,6 +2505,12 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +609,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_hashes 0.11.0",
  "bitcoincore-rpc",
+ "clap",
  "futures",
  "hex",
  "jemallocator",
@@ -647,6 +697,52 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "convert_case"
@@ -994,6 +1090,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1254,12 @@ name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -1354,7 +1462,7 @@ dependencies = [
  "libc 0.2.147",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1480,7 +1588,7 @@ dependencies = [
  "libc 0.2.147",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -1785,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "rustreexo"
 version = "0.3.0"
-source = "git+https://github.com/mit-dci/rustreexo?rev=9d7afec0354c9f37d7e71a7b7e734e4c6dd374da#9d7afec0354c9f37d7e71a7b7e734e4c6dd374da"
+source = "git+https://github.com/mit-dci/rustreexo?rev=91f70ef#91f70efab9d255d795ae0b086694c958c1ffba47"
 dependencies = [
  "bitcoin_hashes 0.14.0",
  "serde",
@@ -2025,6 +2133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,7 +2266,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2283,6 +2397,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
@@ -2437,7 +2557,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2446,13 +2575,29 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2462,10 +2607,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2474,10 +2631,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2486,16 +2661,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ categories = ["bitcoin", "tools"]
 bitcoin = { version = "0.29" }
 bitcoincore-rpc = "0.16.0"
 bitcoin_hashes = "0.11"
-rustreexo = { git = "https://github.com/mit-dci/rustreexo", rev = "9d7afec0354c9f37d7e71a7b7e734e4c6dd374da", features = ["with-serde"] }
+rustreexo = { git = "https://github.com/mit-dci/rustreexo", rev = "91f70ef", features = ["with-serde"] }
 sha2 = "0.10.6"
 anyhow = "1.0.71"
 kv = "0.24.0"
-actix = "0.13.0"
-actix-web = "4.3.1"
+actix = { version = "0.13.0", optional = true }
+actix-web = { version = "4.3.1", optional = true }
 serde = "1.0.183"
-actix-files = "0.6.2"
-actix-session = "0.7.2"
+actix-files = { version = "0.6.2", optional = true }
+actix-session = { version = "0.7.2", optional = true }
 async-stream = "0.3.5"
 futures = "0.3.28"
 actix-rt = "2.8.0"
@@ -39,17 +39,21 @@ reqwest = { version = "0.11.18", features = [
     "rustls-tls-webpki-roots",
 ], optional = true, default-features = false }
 serde_json = { version = "1.0.128" }
-actix-cors = "0.6.4"
+actix-cors = { version = "0.6.4", optional = true }
 mmap = "0.1.1"
 jemallocator = "0.5.4"
 starknet-crypto = { version = "0.7.2", optional = true }
+clap = { version = "4.5.20", features = ["derive"] }
 
 [patch."https://github.com/rust-lang/crates.io-index"]
 bitcoin = { git = "https://github.com/Davidson-Souza/rust-bitcoin", rev = "a320c6535567acd3771da37759a7644eea5c6eb2" }
 
 [features]
+default = ["bitcoin", "node", "api"]
 esplora = ["reqwest"]
-default = ["shinigami"]
+bitcoin = []
+node = []
+api = ["actix", "actix-web", "actix-session", "actix-cors", "actix-files"]
 shinigami = ["starknet-crypto"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ sha2 = "0.10.6"
 anyhow = "1.0.71"
 kv = "0.24.0"
 actix = { version = "0.13.0", optional = true }
-actix-web = { version = "4.3.1", optional = true }
+actix-web = { version = "4.9", optional = true }
 serde = "1.0.183"
 actix-files = { version = "0.6.2", optional = true }
 actix-session = { version = "0.7.2", optional = true }
@@ -44,12 +44,13 @@ mmap = "0.1.1"
 jemallocator = "0.5.4"
 starknet-crypto = { version = "0.7.2", optional = true }
 clap = { version = "4.5.20", features = ["derive"] }
-
+time = "0.3.36"
+ahash = "0.8.11"
 [patch."https://github.com/rust-lang/crates.io-index"]
 bitcoin = { git = "https://github.com/Davidson-Souza/rust-bitcoin", rev = "a320c6535567acd3771da37759a7644eea5c6eb2" }
 
 [features]
-default = ["api", "node", "bitcoin"]
+default = ["bitcoin", "node", "api"]
 esplora = ["reqwest"]
 bitcoin = []
 node = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["bitcoin", "tools"]
 bitcoin = { version = "0.29" }
 bitcoincore-rpc = "0.16.0"
 bitcoin_hashes = "0.11"
-rustreexo = { version = "0.3.0", features = ["with-serde"] }
+rustreexo = { git = "https://github.com/mit-dci/rustreexo", rev = "9d7afec0354c9f37d7e71a7b7e734e4c6dd374da", features = ["with-serde"] }
 sha2 = "0.10.6"
 anyhow = "1.0.71"
 kv = "0.24.0"
@@ -38,14 +38,18 @@ reqwest = { version = "0.11.18", features = [
     "__rustls",
     "rustls-tls-webpki-roots",
 ], optional = true, default-features = false }
-serde_json = { version = "1.0.104", optional = true }
+serde_json = { version = "1.0.128" }
 actix-cors = "0.6.4"
 mmap = "0.1.1"
 jemallocator = "0.5.4"
+starknet-crypto = { version = "0.7.2", optional = true }
 
 [patch."https://github.com/rust-lang/crates.io-index"]
 bitcoin = { git = "https://github.com/Davidson-Souza/rust-bitcoin", rev = "a320c6535567acd3771da37759a7644eea5c6eb2" }
 
 [features]
-esplora = ["reqwest", "serde_json"]
-default = []
+esplora = ["reqwest"]
+default = ["shinigami"]
+shinigami = ["starknet-crypto"]
+
+[dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ clap = { version = "4.5.20", features = ["derive"] }
 bitcoin = { git = "https://github.com/Davidson-Souza/rust-bitcoin", rev = "a320c6535567acd3771da37759a7644eea5c6eb2" }
 
 [features]
-default = ["bitcoin", "node", "api"]
+default = ["shinigami"]
 esplora = ["reqwest"]
 bitcoin = []
 node = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ clap = { version = "4.5.20", features = ["derive"] }
 bitcoin = { git = "https://github.com/Davidson-Souza/rust-bitcoin", rev = "a320c6535567acd3771da37759a7644eea5c6eb2" }
 
 [features]
-default = ["shinigami"]
+default = ["api", "node", "bitcoin"]
 esplora = ["reqwest"]
 bitcoin = []
 node = []

--- a/README.md
+++ b/README.md
@@ -94,7 +94,24 @@ There are a few environment variables that can be used to configure the bridge n
 - [ ] Support for tor onion services
 - [x] Support for ipv6
 - [ ] Push roots over nostr on every block
-... and more ...
+- [ ] ... and more ...
+
+## Feature flags
+
+We have a few feature flags that can be used to enable or disable some features of the bridge node. Here's a list of all available feature flags:
+ - `esplora`: Enables the use of esplora backends to grab blocks and transactions. This can replace the usage of Bitcoin Core as a backend.
+ - `node`: Enables a small p2p node that will serve blocks and transactions over the network to other nodes and clients.
+ - `api`: Enables the REST API that can be used to query the node for proofs.
+ - `shinigami`: This feature is used to enable compatibility with [starknet's Cairo prover](https://github.com/keep-starknet-strange/raito/) for the Bitcoin protocol. This will disable the node and API, use Poseidon as the accumulator hash function and save data in JSON files.
+
+The deafult features are `bitcoin`, `node` and `api`. To change this, you can use the `--no-default-features` flag when building the node. For example, to build with the `shinigami` feature, you can use the following command:
+
+```bash
+cargo build --release --no-default-features --features shinigami
+```
+
+If you don't provide either `bitcoin` or `shinigami`, you'll have a compile error. You also can't use both at the same time. The API and node,
+currently, are not compatible with the `shinigami` feature.
 
 ## License
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -21,7 +21,7 @@ use bitcoincore_rpc::jsonrpc::serde_json::json;
 use futures::channel::mpsc::Sender;
 use futures::lock::Mutex;
 use futures::SinkExt;
-use rustreexo::accumulator::node_hash::NodeHash;
+use rustreexo::accumulator::node_hash::BitcoinNodeHash;
 use rustreexo::accumulator::proof::Proof;
 use serde::Deserialize;
 use serde::Serialize;
@@ -85,7 +85,7 @@ async fn get_tx_unspent(hash: web::Path<Txid>, data: web::Data<AppState>) -> imp
 /// it exists.
 async fn get_proof(hash: web::Path<String>, data: web::Data<AppState>) -> impl Responder {
     let hash = hash.into_inner();
-    let hash = NodeHash::from_str(&hash);
+    let hash = BitcoinNodeHash::from_str(&hash);
 
     if let Err(e) = hash {
         return HttpResponse::BadRequest().body(format!("Invalid hash {e}"));
@@ -326,7 +326,7 @@ impl From<UtreexoBlock> for UBlock {
             hashes: proof
                 .hashes
                 .iter()
-                .map(|x| NodeHash::from(x.as_inner()))
+                .map(|x| BitcoinNodeHash::from(x.as_inner()))
                 .collect(),
             targets: proof.targets.iter().map(|x| x.0).collect(),
         }

--- a/src/bitcoin_bridge.rs
+++ b/src/bitcoin_bridge.rs
@@ -1,0 +1,140 @@
+use std::env;
+use std::fs;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::RwLock;
+
+use actix_rt::signal::ctrl_c;
+use futures::channel::mpsc::channel;
+use log::info;
+use log::warn;
+
+use crate::api;
+use crate::blockfile::BlockFile;
+use crate::blockfile::BlocksIndex;
+use crate::chainview;
+use crate::get_chain_provider;
+use crate::init_logger;
+use crate::leaf_cache::DiskLeafStorage;
+use crate::node;
+use crate::node::Node;
+use crate::prover;
+use crate::subdir;
+
+pub fn run_bridge() -> anyhow::Result<()> {
+    fs::DirBuilder::new()
+        .recursive(true)
+        .create(subdir(""))
+        .unwrap();
+
+    // Initialize the logger
+    init_logger(
+        Some(&subdir("debug.log")),
+        simplelog::LevelFilter::Info,
+        true,
+    );
+
+    // to keep track of the current chain state and speed up replying to headers requests
+    // from peers.
+    let store = kv::Store::new(kv::Config {
+        path: subdir("chain_view").into(),
+        temporary: false,
+        use_compression: false,
+        flush_every_ms: None,
+        cache_capacity: None,
+        segment_size: None,
+    })
+    .expect("Failed to open chainview database");
+
+    // Chainview is a collection of metadata about the chain, like tip and block
+    // indexes. It's stored in a key-value database.
+    let view = chainview::ChainView::new(store);
+    let view = Arc::new(view);
+
+    // This database stores some useful information about the blocks, but not
+    // the blocks themselves
+    let index_store = BlocksIndex {
+        database: kv::Store::new(kv::Config {
+            path: subdir("index/").into(),
+            temporary: false,
+            use_compression: false,
+            flush_every_ms: Some(1000),
+            cache_capacity: Some(1_000_000),
+            segment_size: None,
+        })
+        .unwrap(),
+    };
+
+    // Put it into an Arc so we can share it between threads
+    let index_store = Arc::new(index_store);
+
+    // This database stores the blocks themselves, it's a collection of flat files
+    // that are indexed by the index above. They are stored in the `blocks/` directory
+    // and are serialized as bitcoin blocks, so we don't need to do any parsing
+    // before sending to a peer.
+    let blocks = Arc::new(RwLock::new(
+        BlockFile::new(subdir("blocks").into(), 10_000_000_000).expect("Could not open block file"),
+    ));
+
+    // The prover needs some way to pull blocks from a trusted source, we can use anything
+    // implementing the [Blockchain] trait, for example a bitcoin core node or an esplora
+    // instance.
+    let client = get_chain_provider()?;
+
+    // Create a prover, this module will download blocks from the bitcoin core
+    // node and save them to disk. It will also create proofs for the blocks
+    // and save them to disk.
+    let leaf_data = DiskLeafStorage::new(&subdir("leaf_data"));
+    //let leaf_data = HashMap::new();
+    let mut prover = prover::Prover::new(
+        client,
+        index_store.clone(),
+        blocks.clone(),
+        view.clone(),
+        leaf_data,
+    );
+    info!("Starting p2p node");
+
+    // This is our implementation of the Bitcoin p2p protocol, it will listen
+    // for incoming connections and serve blocks and proofs to peers.
+    let p2p_port = env::var("P2P_PORT").unwrap_or_else(|_| "8333".into());
+    let p2p_address = format!(
+        "{}:{}",
+        env::var("P2P_HOST").unwrap_or_else(|_| "0.0.0.0".into()),
+        p2p_port
+    );
+
+    let listener = std::net::TcpListener::bind(p2p_address).unwrap();
+    let node = node::Node::new(listener, blocks, index_store, view.clone());
+    std::thread::spawn(move || {
+        Node::accept_connections(node);
+    });
+
+    let (sender, receiver) = channel(1024);
+
+    // This is our implementation of the json-rpc api, it will listen for
+    // incoming connections and serve some Utreexo data to clients.
+    info!("Starting api");
+    let host = env::var("API_HOST").unwrap_or_else(|_| "127.0.0.1:3000".into());
+    std::thread::spawn(move || {
+        actix_rt::System::new()
+            .block_on(api::create_api(sender, view, &host))
+            .unwrap()
+    });
+
+    let kill_signal = Arc::new(Mutex::new(false));
+    let kill_signal2 = kill_signal.clone();
+
+    // Keep the prover running in the background, it will download blocks and
+    // create proofs for them as they are mined.
+    info!("Running prover");
+    std::thread::spawn(move || {
+        actix_rt::System::new().block_on(async {
+            let _ = ctrl_c().await;
+            warn!("Received a stop signal");
+            *kill_signal.lock().unwrap() = true;
+        })
+    });
+
+    prover.keep_up(kill_signal2, receiver)
+}

--- a/src/bitcoin_bridge.rs
+++ b/src/bitcoin_bridge.rs
@@ -94,7 +94,7 @@ pub fn run_bridge() -> anyhow::Result<()> {
         leaf_data,
         None,
         None,
-        None
+        None,
     );
     info!("Starting p2p node");
 

--- a/src/bitcoin_bridge.rs
+++ b/src/bitcoin_bridge.rs
@@ -92,6 +92,9 @@ pub fn run_bridge() -> anyhow::Result<()> {
         blocks.clone(),
         view.clone(),
         leaf_data,
+        None,
+        None,
+        None
     );
     info!("Starting p2p node");
 

--- a/src/bitcoin_bridge.rs
+++ b/src/bitcoin_bridge.rs
@@ -10,8 +10,8 @@ use log::info;
 use log::warn;
 
 use crate::api;
+use crate::block_index::BlocksIndex;
 use crate::blockfile::BlockFile;
-use crate::blockfile::BlocksIndex;
 use crate::chainview;
 use crate::get_chain_provider;
 use crate::init_logger;

--- a/src/block_index.rs
+++ b/src/block_index.rs
@@ -1,0 +1,101 @@
+use bitcoin::BlockHash;
+use bitcoin::hashes::Hash;
+
+/// We use this index to keep track of information held on flat files. Right now we only store the
+/// blocks in the file, but if we build things like compact block filters, we can reuse the
+/// indexing logic.
+pub enum IndexEntry {
+    /// The index of a block in the file.
+    Index(BlockIndex),
+}
+
+#[derive(Debug)]
+/// The index of a block in a file. Each block have an associated index entry.
+pub struct BlockIndex {
+    /// The offset of the block in the file counted from the file's begginning, in bytes.
+    pub offset: usize,
+    /// The size of the block in bytes.
+    pub size: usize,
+}
+
+impl kv::Value for IndexEntry {
+    fn from_raw_value(r: kv::Raw) -> Result<Self, kv::Error> {
+        Ok(IndexEntry::Index(BlockIndex {
+            size: u64::from_be_bytes(r[..8].try_into().unwrap()) as usize,
+            offset: u64::from_be_bytes(r[8..].try_into().unwrap()) as usize,
+        }))
+    }
+
+    fn to_raw_value(&self) -> Result<kv::Raw, kv::Error> {
+        match self {
+            IndexEntry::Index(index) => {
+                let mut buf = Vec::new();
+                buf.extend_from_slice(&(index.size as u64).to_be_bytes());
+                buf.extend_from_slice(&(index.offset as u64).to_be_bytes());
+                Ok(kv::Raw::from(buf))
+            }
+        }
+    }
+}
+
+/// An index to help us finding blocks and heights.
+///
+/// This keeps track of where in the file each block is stored, so we can quickly access them.
+pub struct BlocksIndex {
+    pub database: kv::Store,
+}
+
+impl BlocksIndex {
+    /// Returns the index for a block, given its hash. If the block is not found, it returns None.
+    pub fn get_index<'a>(&self, block: BlockHash) -> Option<BlockIndex> {
+        let bucket = self
+            .database
+            .bucket::<&'a [u8], IndexEntry>(Some("index"))
+            .unwrap();
+
+        let key: [u8; 32] = block.into_inner();
+        match bucket.get(&key.as_slice()) {
+            Ok(Some(IndexEntry::Index(index))) => Some(index),
+            _ => None,
+        }
+    }
+
+    /// Saves the height of the latest block we have in the index.
+    pub fn update_height<'a>(&self, height: usize) {
+        let bucket = self
+            .database
+            .bucket::<&'a [u8], Vec<u8>>(Some("meta"))
+            .unwrap();
+        let key = b"height";
+        bucket
+            .set(&key.as_slice(), &height.to_be_bytes().to_vec())
+            .expect("Failed to write index");
+        bucket.flush().unwrap();
+    }
+
+    /// Returns the height of the latest block we have in the index.
+    pub fn load_height<'a>(&self) -> usize {
+        let bucket = self
+            .database
+            .bucket::<&'a [u8], Vec<u8>>(Some("meta"))
+            .unwrap();
+        let key = b"height";
+        let height = bucket.get(&key.as_slice());
+        match height {
+            Ok(Some(height)) => usize::from_be_bytes(height[..].try_into().unwrap()),
+            _ => 0,
+        }
+    }
+
+    /// Appends a new block entry to the index.
+    pub fn append<'a>(&self, index: BlockIndex, block: BlockHash) {
+        let bucket = self
+            .database
+            .bucket::<&'a [u8], IndexEntry>(Some("index"))
+            .unwrap();
+        let key: [u8; 32] = block.into_inner();
+        bucket
+            .set(&key.as_slice(), &IndexEntry::Index(index))
+            .expect("Failed to write index");
+    }
+}

--- a/src/block_index.rs
+++ b/src/block_index.rs
@@ -48,7 +48,7 @@ pub struct BlocksIndex {
 impl BlocksIndex {
     /// Returns the index for a block, given its hash. If the block is not found, it returns None.
     #[allow(dead_code)]
-    pub fn get_index<'a>(&self, block: BlockHash) -> Option<BlockIndex> {
+    pub fn get_index<'a>(&'a self, block: BlockHash) -> Option<BlockIndex> {
         let bucket = self
             .database
             .bucket::<&'a [u8], IndexEntry>(Some("index"))
@@ -62,7 +62,7 @@ impl BlocksIndex {
     }
 
     /// Saves the height of the latest block we have in the index.
-    pub fn update_height<'a>(&self, height: usize) {
+    pub fn update_height<'a>(&'a self, height: usize) {
         let bucket = self
             .database
             .bucket::<&'a [u8], Vec<u8>>(Some("meta"))
@@ -75,7 +75,7 @@ impl BlocksIndex {
     }
 
     /// Returns the height of the latest block we have in the index.
-    pub fn load_height<'a>(&self) -> usize {
+    pub fn load_height<'a>(&'a self) -> usize {
         let bucket = self
             .database
             .bucket::<&'a [u8], Vec<u8>>(Some("meta"))
@@ -89,7 +89,7 @@ impl BlocksIndex {
     }
 
     /// Appends a new block entry to the index.
-    pub fn append<'a>(&self, index: BlockIndex, block: BlockHash) {
+    pub fn append<'a>(&'a self, index: BlockIndex, block: BlockHash) {
         let bucket = self
             .database
             .bucket::<&'a [u8], IndexEntry>(Some("index"))

--- a/src/block_index.rs
+++ b/src/block_index.rs
@@ -1,5 +1,5 @@
-use bitcoin::BlockHash;
 use bitcoin::hashes::Hash;
+use bitcoin::BlockHash;
 
 /// We use this index to keep track of information held on flat files. Right now we only store the
 /// blocks in the file, but if we build things like compact block filters, we can reuse the
@@ -47,6 +47,7 @@ pub struct BlocksIndex {
 
 impl BlocksIndex {
     /// Returns the index for a block, given its hash. If the block is not found, it returns None.
+    #[allow(dead_code)]
     pub fn get_index<'a>(&self, block: BlockHash) -> Option<BlockIndex> {
         let bucket = self
             .database

--- a/src/blockfile.rs
+++ b/src/blockfile.rs
@@ -15,10 +15,18 @@ use std::slice;
 use bitcoin::consensus::Decodable;
 use bitcoin::consensus::Encodable;
 use bitcoin::hashes::Hash;
+use bitcoin::network::utreexo::BatchProof;
+use bitcoin::network::utreexo::CompactLeafData;
+use bitcoin::network::utreexo::ScriptPubkeyType;
+use bitcoin::network::utreexo::UData;
 use bitcoin::network::utreexo::UtreexoBlock as Block;
 use bitcoin::BlockHash;
+use bitcoin::Script;
+use bitcoin::VarInt;
 use mmap::MapOption;
 use mmap::MemoryMap;
+
+use crate::prover::BlockStorage;
 
 /// A file that holds all blocks and proofs in a memory-mapped file.
 pub struct BlockFile {
@@ -59,14 +67,14 @@ impl BlockFile {
             file,
         })
     }
-    
+
     /// Returns a block at the given position.
     pub fn get_block(&self, index: BlockIndex) -> Option<Block> {
         unsafe {
             Block::consensus_decode(&mut slice::from_raw_parts(self.read(&index), index.size)).ok()
         }
     }
-    
+
     /// Appends a block to the file and returns the index of the block.
     pub fn append(&mut self, block: &Block) -> BlockIndex {
         // seek to the end of the file
@@ -79,110 +87,64 @@ impl BlockFile {
             size,
         }
     }
-    
+
     /// Returns a pointer to the block at the given index.
     ///
     /// This funcion is unsafe because it returns a raw pointer to the memory-mapped region.
     pub unsafe fn read(&self, index: &BlockIndex) -> *mut u8 {
         self.mmap.data().wrapping_add(index.offset)
     }
-}
 
-/// We use this index to keep track of information held on flat files. Right now we only store the
-/// blocks in the file, but if we build things like compact block filters, we can reuse the
-/// indexing logic.
-pub enum IndexEntry {
-    /// The index of a block in the file.
-    Index(BlockIndex),
-}
-
-#[derive(Debug)]
-/// The index of a block in a file. Each block have an associated index entry.
-pub struct BlockIndex {
-    /// The offset of the block in the file counted from the file's begginning, in bytes.
-    pub offset: usize,
-    /// The size of the block in bytes.
-    pub size: usize,
-}
-
-impl kv::Value for IndexEntry {
-    fn from_raw_value(r: kv::Raw) -> Result<Self, kv::Error> {
-        Ok(IndexEntry::Index(BlockIndex {
-            size: u64::from_be_bytes(r[..8].try_into().unwrap()) as usize,
-            offset: u64::from_be_bytes(r[8..].try_into().unwrap()) as usize,
-        }))
+    /// Returns what spk type this output is. We need this to build a compact leaf data.
+    fn get_spk_type(spk: &Script) -> ScriptPubkeyType {
+        if spk.is_p2pkh() {
+            ScriptPubkeyType::PubKeyHash
+        } else if spk.is_p2sh() {
+            ScriptPubkeyType::ScriptHash
+        } else if spk.is_v0_p2wpkh() {
+            ScriptPubkeyType::WitnessV0PubKeyHash
+        } else if spk.is_v0_p2wsh() {
+            ScriptPubkeyType::WitnessV0ScriptHash
+        } else {
+            ScriptPubkeyType::Other(spk.to_bytes().into_boxed_slice())
+        }
     }
+}
 
-    fn to_raw_value(&self) -> Result<kv::Raw, kv::Error> {
-        match self {
-            IndexEntry::Index(index) => {
-                let mut buf = Vec::new();
-                buf.extend_from_slice(&(index.size as u64).to_be_bytes());
-                buf.extend_from_slice(&(index.offset as u64).to_be_bytes());
-                Ok(kv::Raw::from(buf))
+impl BlockStorage for BlockFile {
+    fn save_block(
+        &self,
+        block: bitcoin::Block,
+        block_height: u32,
+        proof: rustreexo::accumulator::proof::Proof<crate::prover::AccumulatorHash>,
+        leaves: Vec<crate::udata::LeafContext>,
+        acc: &rustreexo::accumulator::pollard::Pollard<crate::prover::AccumulatorHash>,
+    ) -> BlockIndex {
+        let batch_proof = BatchProof {
+            targets: proof.targets.iter().map(|x| VarInt(*x)).collect(),
+            hashes: proof.hashes,
+        };
+        
+        let leaves = leaves.into_iter().map(|leaf| {
+            let header_code = leaf.block_height << 1 | leaf.is_coinbase as u32;
+            
+            CompactLeafData {
+                header_code,
+                amount: leaf.value,
+                spk_ty: Self::get_spk_type(&leaf.pk_script),
             }
-        }
+        }).collect();
+
+        let block = bitcoin::network::utreexo::UtreexoBlock {
+            block,
+            udata: Some(UData {
+                remember_idx: vec![],
+                proof: batch_proof,
+                leaves,
+            }),
+        };
+
+        self.append(&block)
     }
 }
 
-/// An index to help us finding blocks and heights.
-///
-/// This keeps track of where in the file each block is stored, so we can quickly access them.
-pub struct BlocksIndex {
-    pub database: kv::Store,
-}
-
-impl BlocksIndex {
-    /// Returns the index for a block, given its hash. If the block is not found, it returns None.
-    pub fn get_index<'a>(&self, block: BlockHash) -> Option<BlockIndex> {
-        let bucket = self
-            .database
-            .bucket::<&'a [u8], IndexEntry>(Some("index"))
-            .unwrap();
-
-        let key: [u8; 32] = block.into_inner();
-        match bucket.get(&key.as_slice()) {
-            Ok(Some(IndexEntry::Index(index))) => Some(index),
-            _ => None,
-        }
-    }
-    
-    /// Saves the height of the latest block we have in the index.
-    pub fn update_height<'a>(&self, height: usize) {
-        let bucket = self
-            .database
-            .bucket::<&'a [u8], Vec<u8>>(Some("meta"))
-            .unwrap();
-        let key = b"height";
-        bucket
-            .set(&key.as_slice(), &height.to_be_bytes().to_vec())
-            .expect("Failed to write index");
-        bucket.flush().unwrap();
-    }
-    
-    /// Returns the height of the latest block we have in the index.
-    pub fn load_height<'a>(&self) -> usize {
-        let bucket = self
-            .database
-            .bucket::<&'a [u8], Vec<u8>>(Some("meta"))
-            .unwrap();
-        let key = b"height";
-        let height = bucket.get(&key.as_slice());
-        match height {
-            Ok(Some(height)) => usize::from_be_bytes(height[..].try_into().unwrap()),
-            _ => 0,
-        }
-    }
-    
-    /// Appends a new block entry to the index.
-    pub fn append<'a>(&self, index: BlockIndex, block: BlockHash) {
-        let bucket = self
-            .database
-            .bucket::<&'a [u8], IndexEntry>(Some("index"))
-            .unwrap();
-        let key: [u8; 32] = block.into_inner();
-        bucket
-            .set(&key.as_slice(), &IndexEntry::Index(index))
-            .expect("Failed to write index");
-    }
-}

--- a/src/chaininterface.rs
+++ b/src/chaininterface.rs
@@ -70,12 +70,11 @@ impl Blockchain for Client {
             is_coinbase: tx_data.is_coinbase(),
         })
     }
-    
+
     fn get_mtp(&self, block_hash: BlockHash) -> Result<u32> {
         let info = self.get_block_info(&block_hash)?;
         Ok(info.mediantime.unwrap_or(info.time) as u32)
     }
-
 }
 #[derive(Debug)]
 pub struct TransactionInfo {
@@ -123,23 +122,23 @@ impl<T: Blockchain> Blockchain for &Box<T> {
     fn get_block(&self, block_hash: BlockHash) -> Result<Block> {
         (**self).get_block(block_hash)
     }
-    
+
     fn get_transaction(&self, txid: Txid) -> Result<Transaction> {
         (**self).get_transaction(txid)
     }
-    
+
     fn get_block_hash(&self, height: u64) -> Result<BlockHash> {
         (**self).get_block_hash(height)
     }
-    
+
     fn get_block_height(&self, block_hash: BlockHash) -> Result<u32> {
         (**self).get_block_height(block_hash)
     }
-    
+
     fn get_block_header(&self, block_hash: BlockHash) -> Result<BlockHeader> {
         (**self).get_block_header(block_hash)
     }
-    
+
     fn get_block_count(&self) -> Result<u64> {
         (**self).get_block_count()
     }

--- a/src/chaininterface.rs
+++ b/src/chaininterface.rs
@@ -30,28 +30,36 @@ pub trait Blockchain {
     fn get_block_count(&self) -> Result<u64>;
     /// Returns the raw transaction info, given a transaction id.
     fn get_raw_transaction_info(&self, txid: &Txid) -> Result<TransactionInfo>;
+    /// Returns the median time past of the block with the given hash.
+    fn get_mtp(&self, block_hash: BlockHash) -> Result<u32>;
 }
 
 impl Blockchain for Client {
     fn get_block(&self, block_hash: BlockHash) -> Result<Block> {
         Ok(<Self as RpcApi>::get_block(self, &block_hash)?)
     }
+
     fn get_transaction(&self, txid: Txid) -> Result<Transaction> {
         Ok(self.get_raw_transaction(&txid, None)?)
     }
+
     fn get_block_hash(&self, height: u64) -> Result<BlockHash> {
         Ok(<Self as RpcApi>::get_block_hash(self, height)?)
     }
+
     fn get_block_height(&self, block_hash: BlockHash) -> Result<u32> {
         let info = self.get_block_info(&block_hash)?;
         Ok(info.height as u32)
     }
+
     fn get_block_header(&self, block_hash: BlockHash) -> Result<BlockHeader> {
         Ok(<Self as RpcApi>::get_block_header(self, &block_hash)?)
     }
+
     fn get_block_count(&self) -> Result<u64> {
         Ok(<Self as RpcApi>::get_block_count(self)?)
     }
+
     fn get_raw_transaction_info(&self, txid: &Txid) -> Result<TransactionInfo> {
         let tx_data = <Self as RpcApi>::get_raw_transaction_info(self, txid, None)?;
         let height = self.get_block_height(tx_data.blockhash.unwrap()).unwrap();
@@ -62,6 +70,12 @@ impl Blockchain for Client {
             is_coinbase: tx_data.is_coinbase(),
         })
     }
+    
+    fn get_mtp(&self, block_hash: BlockHash) -> Result<u32> {
+        let info = self.get_block_info(&block_hash)?;
+        Ok(info.mediantime.unwrap_or(info.time) as u32)
+    }
+
 }
 #[derive(Debug)]
 pub struct TransactionInfo {
@@ -75,23 +89,33 @@ impl<T: Blockchain + Sized> Blockchain for Box<T> {
     fn get_block(&self, block_hash: BlockHash) -> Result<Block> {
         (**self).get_block(block_hash)
     }
+
     fn get_transaction(&self, txid: Txid) -> Result<Transaction> {
         (**self).get_transaction(txid)
     }
+
     fn get_block_hash(&self, height: u64) -> Result<BlockHash> {
         (**self).get_block_hash(height)
     }
+
     fn get_block_height(&self, block_hash: BlockHash) -> Result<u32> {
         (**self).get_block_height(block_hash)
     }
+
     fn get_block_header(&self, block_hash: BlockHash) -> Result<BlockHeader> {
         (**self).get_block_header(block_hash)
     }
+
     fn get_block_count(&self) -> Result<u64> {
         (**self).get_block_count()
     }
+
     fn get_raw_transaction_info(&self, txid: &Txid) -> Result<TransactionInfo> {
         (**self).get_raw_transaction_info(txid)
+    }
+
+    fn get_mtp(&self, block_hash: BlockHash) -> Result<u32> {
+        (**self).get_mtp(block_hash)
     }
 }
 
@@ -99,22 +123,32 @@ impl<T: Blockchain> Blockchain for &Box<T> {
     fn get_block(&self, block_hash: BlockHash) -> Result<Block> {
         (**self).get_block(block_hash)
     }
+    
     fn get_transaction(&self, txid: Txid) -> Result<Transaction> {
         (**self).get_transaction(txid)
     }
+    
     fn get_block_hash(&self, height: u64) -> Result<BlockHash> {
         (**self).get_block_hash(height)
     }
+    
     fn get_block_height(&self, block_hash: BlockHash) -> Result<u32> {
         (**self).get_block_height(block_hash)
     }
+    
     fn get_block_header(&self, block_hash: BlockHash) -> Result<BlockHeader> {
         (**self).get_block_header(block_hash)
     }
+    
     fn get_block_count(&self) -> Result<u64> {
         (**self).get_block_count()
     }
+
     fn get_raw_transaction_info(&self, txid: &Txid) -> Result<TransactionInfo> {
         (**self).get_raw_transaction_info(txid)
+    }
+
+    fn get_mtp(&self, block_hash: BlockHash) -> Result<u32> {
+        (**self).get_mtp(block_hash)
     }
 }

--- a/src/chainview.rs
+++ b/src/chainview.rs
@@ -10,6 +10,7 @@ pub struct ChainView {
     storage: Store,
 }
 
+#[allow(dead_code)] // FIXME: Remove this
 impl ChainView {
     pub fn new(storage: Store) -> Self {
         Self { storage }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,20 @@
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub struct CliArgs {
+    /// If you want to run the bridge from a specific height, you can specify it here.
+    ///
+    /// Notice that this requires passing the initial state path, that should point to a valid
+    /// accumulator state at the specified height.
+    #[clap(long, requires("initial-state-path"))]
+    pub start_height: Option<u32>,
+    /// The path to the initial state file. This file should contain the accumulator state at the
+    /// specified height.
+    #[clap(long, requires("start_height"))]
+    pub initial_state_path: Option<String>,
+    /// Creates a snapshot of the accumulator every n blocks
+    ///
+    /// The file will be named <height>.acc
+    #[clap(long)]
+    pub acc_snapshot_every_n_blocks: Option<u32>,
+}

--- a/src/leaf_cache.rs
+++ b/src/leaf_cache.rs
@@ -56,9 +56,9 @@ impl LeafCache for DiskLeafStorage {
 impl DiskLeafStorage {
     pub fn new(dir: &str) -> Self {
         let db = kv::Store::new(Config {
-            cache_capacity: None,
+            cache_capacity: Some(1_000_000),
             path: dir.into(),
-            flush_every_ms: Some(10000),
+            flush_every_ms: Some(100),
             segment_size: None,
             temporary: false,
             use_compression: false,

--- a/src/leaf_cache.rs
+++ b/src/leaf_cache.rs
@@ -8,7 +8,7 @@ use kv::Config;
 use log::info;
 
 use crate::prover::LeafCache;
-use crate::udata::LeafData;
+use crate::udata::LeafContext;
 
 pub struct DiskLeafStorage {
     /// In-memory cache of leaf data
@@ -18,7 +18,7 @@ pub struct DiskLeafStorage {
     /// flush it to disk.
     /// If we die before flushing, we'll need txindex to rebuild the
     /// cache.
-    cache: HashMap<OutPoint, (u32, LeafData)>,
+    cache: HashMap<OutPoint, (u32, LeafContext)>,
     /// A disk database of leaf data
     ///
     /// This is used to store leaf data that is not in the cache,
@@ -27,20 +27,37 @@ pub struct DiskLeafStorage {
 }
 
 impl LeafCache for DiskLeafStorage {
-    fn insert(&mut self, outpoint: OutPoint, leaf_data: LeafData) -> bool {
-        let height = leaf_data.header_code >> 1;
-        self.cache.insert(outpoint, (height, leaf_data));
+    fn insert(&mut self, outpoint: OutPoint, leaf_data: LeafContext) -> bool {
+        self.cache
+            .insert(outpoint, (leaf_data.block_height, leaf_data));
         self.cache.len() > 100_000
     }
 
-    fn remove(&mut self, outpoint: &OutPoint) -> Option<LeafData> {
+    fn remove(&mut self, outpoint: &OutPoint) -> Option<LeafContext> {
         self.cache
             .remove(outpoint)
             .map(|(_, leaf_data)| leaf_data)
             .or_else(|| {
                 let leaf = self.bucket.remove(&serialize(outpoint)).ok().flatten()?;
+                let block_height = deserialize(&leaf[0..4]).unwrap();
+                let txid = deserialize(&leaf[4..36]).unwrap();
+                let vout = deserialize(&leaf[36..40]).unwrap();
+                let value = deserialize(&leaf[40..48]).unwrap();
+                let block_hash = deserialize(&leaf[48..80]).unwrap();
+                let is_coinbase = deserialize(&leaf[80..81]).unwrap();
+                let median_time_past = deserialize(&leaf[81..85]).unwrap();
+                let pk_script = deserialize(&leaf[85..]).unwrap();
 
-                deserialize(&leaf).ok()
+                Some(LeafContext {
+                    block_height,
+                    txid,
+                    vout,
+                    value,
+                    pk_script,
+                    block_hash,
+                    is_coinbase,
+                    median_time_past,
+                })
             })
     }
 
@@ -75,6 +92,18 @@ impl DiskLeafStorage {
         self.cache.len()
     }
 
+    fn serialize_leaf_data(leaf_data: &LeafContext) -> Vec<u8> {
+        let mut serialized = serialize(&leaf_data.block_height);
+        serialized.extend_from_slice(&serialize(&leaf_data.txid));
+        serialized.extend_from_slice(&serialize(&leaf_data.vout));
+        serialized.extend_from_slice(&serialize(&leaf_data.value));
+        serialized.extend_from_slice(&serialize(&leaf_data.block_hash));
+        serialized.extend_from_slice(&serialize(&leaf_data.is_coinbase));
+        serialized.extend_from_slice(&serialize(&leaf_data.median_time_past));
+        serialized.extend_from_slice(&leaf_data.pk_script.as_bytes());
+        serialized
+    }
+
     fn flush(&mut self) {
         info!("Flushing leaf cache to disk, this might take a while");
         let mut new_map = HashMap::new();
@@ -86,7 +115,7 @@ impl DiskLeafStorage {
                 continue;
             }
 
-            let serialized = serialize(&leaf_data);
+            let serialized = Self::serialize_leaf_data(&leaf_data);
             batch
                 .set(&serialize(outpoint), &serialized)
                 .expect("Failed to flush leaf cache");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,43 @@
 //SPDX-License-Identifier: MIT
 
+#[cfg(all(feature = "shinigami", feature = "bitcoin"))]
+compile_error!("You can't have both shinigami and bitcoin features enabled at the same time");
+
+#[cfg(all(not(feature = "shinigami"), not(feature = "bitcoin")))]
+compile_error!("You must enable either the shinigami or the bitcoin feature");
+
+#[cfg(all(feature = "shinigami", feature = "api"))]
+compile_error!("This combination is not supported yet");
+
+#[cfg(all(feature = "shinigami", feature = "node"))]
+compile_error!("This combination is not supported yet");
+
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-#[cfg(not(feature = "shinigami"))]
+#[cfg(feature = "api")]
 mod api;
+
 #[cfg(not(feature = "shinigami"))]
 mod blockfile;
+
+#[cfg(feature = "esplora")]
+mod esplora;
+
+#[cfg(not(feature = "shinigami"))]
+mod leaf_cache;
+
+#[cfg(feature = "node")]
+mod node;
+
+mod prover;
+
+#[cfg(feature = "shinigami")]
+mod shinigami_block_storage;
+
 mod block_index;
 mod chaininterface;
 mod chainview;
-#[cfg(feature = "esplora")]
-mod esplora;
-#[cfg(not(feature = "shinigami"))]
-mod leaf_cache;
-#[cfg(not(feature = "shinigami"))]
-mod node;
-mod prover;
-mod shinigami_block_storage;
 mod udata;
 
 use std::env;
@@ -121,6 +141,7 @@ fn get_chain_provider() -> Result<Box<dyn Blockchain>> {
     }
 }
 
+#[cfg(not(feature = "shinigami"))]
 macro_rules! try_and_log_error {
     ($op:expr) => {
         if let Err(e) = $op {
@@ -129,4 +150,5 @@ macro_rules! try_and_log_error {
     };
 }
 
+#[cfg(not(feature = "shinigami"))]
 pub(crate) use try_and_log_error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ mod shinigami_block_storage;
 mod block_index;
 mod chaininterface;
 mod chainview;
+mod cli;
 mod udata;
 
 use std::env;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,147 +3,48 @@
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
+#[cfg(not(feature = "shinigami"))]
 mod api;
+#[cfg(not(feature = "shinigami"))]
 mod blockfile;
+mod block_index;
 mod chaininterface;
 mod chainview;
 #[cfg(feature = "esplora")]
 mod esplora;
+#[cfg(not(feature = "shinigami"))]
 mod leaf_cache;
+#[cfg(not(feature = "shinigami"))]
 mod node;
 mod prover;
+mod shinigami_block_storage;
 mod udata;
 
 use std::env;
-use std::fs;
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::sync::RwLock;
 
-use actix_rt::signal::ctrl_c;
 use anyhow::Result;
 use bitcoincore_rpc::Auth;
 use bitcoincore_rpc::Client;
-use blockfile::BlocksIndex;
 use chaininterface::Blockchain;
-use futures::channel::mpsc::channel;
+use jemallocator::Jemalloc;
 use log::info;
-use log::warn;
 use simplelog::Config;
 use simplelog::SharedLogger;
-use jemallocator::Jemalloc;
 
-use crate::blockfile::BlockFile;
-use crate::leaf_cache::DiskLeafStorage;
-use crate::node::Node;
+#[cfg(feature = "shinigami")]
+pub mod shinigami_bridge;
+
+#[cfg(feature = "shinigami")]
+use crate::shinigami_bridge::run_bridge;
+
+#[cfg(not(feature = "shinigami"))]
+pub mod bitcoin_bridge;
+
+#[cfg(not(feature = "shinigami"))]
+use crate::bitcoin_bridge::run_bridge;
 
 fn main() -> anyhow::Result<()> {
-    fs::DirBuilder::new()
-        .recursive(true)
-        .create(subdir(""))
-        .unwrap();
-
-    // Initialize the logger
-    init_logger(
-        Some(&subdir("debug.log")),
-        simplelog::LevelFilter::Info,
-        true,
-    );
-    // to keep track of the current chain state and speed up replying to headers requests
-    // from peers.
-    let store = kv::Store::new(kv::Config {
-        path: subdir("chain_view").into(),
-        temporary: false,
-        use_compression: false,
-        flush_every_ms: None,
-        cache_capacity: None,
-        segment_size: None,
-    })
-    .expect("Failed to open chainview database");
-    // Chainview is a collection of metadata about the chain, like tip and block
-    // indexes. It's stored in a key-value database.
-    let view = chainview::ChainView::new(store);
-    let view = Arc::new(view);
-
-    // This database stores some useful information about the blocks, but not
-    // the blocks themselves
-    let index_store = BlocksIndex {
-        database: kv::Store::new(kv::Config {
-            path: subdir("index/").into(),
-            temporary: false,
-            use_compression: false,
-            flush_every_ms: None,
-            cache_capacity: None,
-            segment_size: None,
-        })
-        .unwrap(),
-
-    };
-    // Put it into an Arc so we can share it between threads
-    let index_store = Arc::new(index_store);
-    // This database stores the blocks themselves, it's a collection of flat files
-    // that are indexed by the index above. They are stored in the `blocks/` directory
-    // and are serialized as bitcoin blocks, so we don't need to do any parsing
-    // before sending to a peer.
-    let blocks = Arc::new(RwLock::new(
-        BlockFile::new(subdir("blocks").into(), 10_000_000_000).expect("Could not open block file"),
-    ));
-    // The prover needs some way to pull blocks from a trusted source, we can use anything
-    // implementing the [Blockchain] trait, for example a bitcoin core node or an esplora
-    // instance.
-    let client = get_chain_provider()?;
-    // Create a prover, this module will download blocks from the bitcoin core
-    // node and save them to disk. It will also create proofs for the blocks
-    // and save them to disk.
-    let leaf_data = DiskLeafStorage::new(&subdir("leaf_data"));
-    //let leaf_data = HashMap::new();
-    let mut prover = prover::Prover::new(
-        client,
-        index_store.clone(),
-        blocks.clone(),
-        view.clone(),
-        leaf_data,
-    );
-    info!("Starting p2p node");
-    // This is our implementation of the Bitcoin p2p protocol, it will listen
-    // for incoming connections and serve blocks and proofs to peers.
-    let p2p_port = env::var("P2P_PORT").unwrap_or_else(|_| "8333".into());
-    let p2p_address = format!(
-        "{}:{}",
-        env::var("P2P_HOST").unwrap_or_else(|_| "0.0.0.0".into()),
-        p2p_port
-    );
-    let listener = std::net::TcpListener::bind(p2p_address).unwrap();
-    let node = node::Node::new(listener, blocks, index_store, view.clone());
-    std::thread::spawn(move || {
-        Node::accept_connections(node);
-    });
-    let (sender, receiver) = channel(1024);
-    // This is our implementation of the json-rpc api, it will listen for
-    // incoming connections and serve some Utreexo data to clients.
-    info!("Starting api");
-    let host = env::var("API_HOST").unwrap_or_else(|_| "127.0.0.1:3000".into());
-    std::thread::spawn(move || {
-        actix_rt::System::new()
-            .block_on(api::create_api(sender, view, &host))
-            .unwrap()
-    });
-
-    let kill_signal = Arc::new(Mutex::new(false));
-    let kill_signal2 = kill_signal.clone();
-
-    // Keep the prover running in the background, it will download blocks and
-    // create proofs for them as they are mined.
-    info!("Running prover");
-    std::thread::spawn(move || {
-        actix_rt::System::new().block_on(async {
-            let _ = ctrl_c().await;
-            warn!("Received a stop signal");
-            *kill_signal.lock().unwrap() = true;
-        })
-    });
-
-    prover.keep_up(kill_signal2, receiver)
+    run_bridge()
 }
 
 fn subdir(path: &str) -> String {

--- a/src/node.rs
+++ b/src/node.rs
@@ -17,8 +17,8 @@ use bitcoin::network::message_blockdata::Inventory;
 use log::error;
 use log::info;
 
+use crate::block_index::BlocksIndex;
 use crate::blockfile::BlockFile;
-use crate::blockfile::BlocksIndex;
 use crate::chainview::ChainView;
 use crate::try_and_log_error;
 
@@ -92,7 +92,7 @@ impl Peer {
                                 Some(block) => {
                                     let block = RawNetworkMessage {
                                         magic: request.magic,
-                                        payload: NetworkMessage::Block(block),
+                                        payload: NetworkMessage::Block(block.into()),
                                     };
                                     try_and_log_error!(block.consensus_encode(&mut blocks));
                                 }
@@ -124,7 +124,7 @@ impl Peer {
                                 Some(block) => {
                                     let block = RawNetworkMessage {
                                         magic: request.magic,
-                                        payload: NetworkMessage::Block(block.block.into()),
+                                        payload: NetworkMessage::Block(block.into()),
                                     };
                                     try_and_log_error!(block.consensus_encode(&mut blocks));
                                 }

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -410,10 +410,7 @@ impl<LeafStorage: LeafCache, Storage: BlockStorage> Prover<LeafStorage, Storage>
     /// Pulls the [LeafData] from the bitcoin core rpc. We use this as fallback if we can't find
     /// the leaf in leaf_data. This method is slow and should only be used if we can't find the
     /// leaf in the leaf_data.
-    fn get_input_leaf_hash_from_rpc(
-        rpc: &dyn Blockchain,
-        input: &TxIn,
-    ) -> Option<LeafContext> {
+    fn get_input_leaf_hash_from_rpc(rpc: &dyn Blockchain, input: &TxIn) -> Option<LeafContext> {
         let tx_info = rpc
             .get_raw_transaction_info(&input.previous_output.txid)
             .ok()?;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -547,7 +547,7 @@ pub enum Responses {
     Transaction((Transaction, Proof)),
     /// The CSN of the current acc
     #[allow(clippy::upper_case_acronyms)]
-    CNS(Stump),
+    CSN(Stump),
     /// Multiple blocks and utreexo data for them.
     Blocks(Vec<Vec<u8>>),
     TransactionOut(Vec<TxOut>, Proof),

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -387,7 +387,7 @@ impl<LeafStorage: LeafCache, Storage: BlockStorage> Prover<LeafStorage, Storage>
                 self.leaf_data.cache_size(),
                 block.txdata.len()
             );
-            let mtp = self.rpc.get_mtp(block.block_hash())?;
+            let mtp = self.rpc.get_mtp(block.header.prev_blockhash)?;
             let (proof, leaves) = self.process_block(&block, height, mtp);
             let index = self
                 .files
@@ -417,7 +417,12 @@ impl<LeafStorage: LeafCache, Storage: BlockStorage> Prover<LeafStorage, Storage>
 
         let height = tx_info.height;
         let output = &tx_info.tx.output[input.previous_output.vout as usize];
-        let median_time_past = rpc.get_mtp(tx_info.blockhash?).ok()?;
+        let prev_block = rpc
+            .get_block_header(tx_info.blockhash?)
+            .ok()?
+            .prev_blockhash;
+
+        let median_time_past = rpc.get_mtp(prev_block).ok()?;
 
         Some(LeafContext {
             block_hash: tx_info.blockhash?,

--- a/src/shinigami_block_storage.rs
+++ b/src/shinigami_block_storage.rs
@@ -38,7 +38,7 @@ impl JsonBlockFiles {
 
 impl BlockStorage for JsonBlockFiles {
     fn save_block(
-        &self,
+        &mut self,
         _block: &Block,
         block_height: u32,
         proof: Proof<AccumulatorHash>,
@@ -53,20 +53,24 @@ impl BlockStorage for JsonBlockFiles {
             },
             inclusion_proof: proof,
         };
-        
+
         let subdir_name = block_height - (block_height % 10_000);
         let file_path = self.dir.join(subdir_name.to_string());
-        
-        DirBuilder::new().recursive(true).create(&file_path).unwrap();
-        
+
+        DirBuilder::new()
+            .recursive(true)
+            .create(&file_path)
+            .unwrap();
+
         let file_path = file_path.join(format!("{}.json", block_height));
         let mut file = File::create(file_path).unwrap();
 
         serde_json::to_writer(&mut file, &block_data).unwrap();
 
-        BlockIndex {
-            offset: 0,
-            size: 0,
-        }
+        BlockIndex { offset: 0, size: 0 }
+    }
+
+    fn get_block(&self, _index: BlockIndex) -> Option<Block> {
+        unimplemented!()
     }
 }

--- a/src/shinigami_block_storage.rs
+++ b/src/shinigami_block_storage.rs
@@ -1,0 +1,72 @@
+use std::fs::DirBuilder;
+use std::fs::File;
+use std::path::PathBuf;
+
+use bitcoin::Block;
+use rustreexo::accumulator::pollard::Pollard;
+use rustreexo::accumulator::proof::Proof;
+use serde::Serialize;
+
+use crate::block_index::BlockIndex;
+use crate::prover::AccumulatorHash;
+use crate::prover::BlockStorage;
+use crate::udata::shinigami_udata::PoseidonHash;
+use crate::udata::LeafContext;
+
+#[derive(Debug, Serialize)]
+pub struct UtreexoState {
+    roots: Vec<PoseidonHash>,
+    num_leaves: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BlockData {
+    block_height: u32,
+    utreexo_state: UtreexoState,
+    inclusion_proof: Proof<AccumulatorHash>,
+}
+
+pub struct JsonBlockFiles {
+    dir: PathBuf,
+}
+
+impl JsonBlockFiles {
+    pub fn new(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+}
+
+impl BlockStorage for JsonBlockFiles {
+    fn save_block(
+        &self,
+        _block: &Block,
+        block_height: u32,
+        proof: Proof<AccumulatorHash>,
+        _leaves: Vec<LeafContext>,
+        acc: &Pollard<AccumulatorHash>,
+    ) -> BlockIndex {
+        let block_data = BlockData {
+            block_height,
+            utreexo_state: UtreexoState {
+                roots: acc.get_roots().iter().map(|x| x.get_data()).collect(),
+                num_leaves: acc.leaves,
+            },
+            inclusion_proof: proof,
+        };
+        
+        let subdir_name = block_height - (block_height % 10_000);
+        let file_path = self.dir.join(subdir_name.to_string());
+        
+        DirBuilder::new().recursive(true).create(&file_path).unwrap();
+        
+        let file_path = file_path.join(format!("{}.json", block_height));
+        let mut file = File::create(file_path).unwrap();
+
+        serde_json::to_writer(&mut file, &block_data).unwrap();
+
+        BlockIndex {
+            offset: 0,
+            size: 0,
+        }
+    }
+}

--- a/src/shinigami_bridge.rs
+++ b/src/shinigami_bridge.rs
@@ -1,0 +1,100 @@
+use std::collections::HashMap;
+use std::fs;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::RwLock;
+
+use actix_rt::signal::ctrl_c;
+use log::info;
+use log::warn;
+
+use crate::block_index::BlocksIndex;
+use crate::chainview;
+use crate::get_chain_provider;
+use crate::init_logger;
+use crate::prover;
+use crate::shinigami_block_storage::JsonBlockFiles;
+use crate::subdir;
+
+pub fn run_bridge() -> anyhow::Result<()> {
+    fs::DirBuilder::new()
+        .recursive(true)
+        .create(subdir(""))
+        .unwrap();
+
+    // Initialize the logger
+    init_logger(
+        Some(&subdir("debug.log")),
+        simplelog::LevelFilter::Info,
+        true,
+    );
+
+    // to keep track of the current chain state and speed up replying to headers requests
+    // from peers.
+    let store = kv::Store::new(kv::Config {
+        path: subdir("chain_view").into(),
+        temporary: false,
+        use_compression: false,
+        flush_every_ms: None,
+        cache_capacity: None,
+        segment_size: None,
+    })
+    .expect("Failed to open chainview database");
+
+    // Chainview is a collection of metadata about the chain, like tip and block
+    // indexes. It's stored in a key-value database.
+    let view = chainview::ChainView::new(store);
+    let view = Arc::new(view);
+
+    // This database stores some useful information about the blocks, but not
+    // the blocks themselves
+    let index_store = BlocksIndex {
+        database: kv::Store::new(kv::Config {
+            path: subdir("index/").into(),
+            temporary: false,
+            use_compression: false,
+            flush_every_ms: Some(1000),
+            cache_capacity: Some(1_000_000),
+            segment_size: None,
+        })
+        .unwrap(),
+    };
+
+    // Put it into an Arc so we can share it between threads
+    let index_store = Arc::new(index_store);
+
+    // This database stores the blocks themselves, it's a collection of flat files
+    // that are indexed by the index above. They are stored in the `blocks/` directory
+    // and are serialized as bitcoin blocks, so we don't need to do any parsing
+    // before sending to a peer.
+    let blocks = Arc::new(RwLock::new(JsonBlockFiles::new(subdir("blocks/").into())));
+
+    // The prover needs some way to pull blocks from a trusted source, we can use anything
+    // implementing the [Blockchain] trait, for example a bitcoin core node or an esplora
+    // instance.
+    let client = get_chain_provider()?;
+
+    // Create a prover, this module will download blocks from the bitcoin core
+    // node and save them to disk. It will also create proofs for the blocks
+    // and save them to disk.
+    let leaf_data = HashMap::new();
+    let mut prover = prover::Prover::new(client, index_store, blocks, view, leaf_data);
+
+    info!("Starting p2p node");
+
+    let kill_signal = Arc::new(Mutex::new(false));
+    let kill_signal2 = kill_signal.clone();
+
+    // Keep the prover running in the background, it will download blocks and
+    // create proofs for them as they are mined.
+    info!("Running prover");
+    std::thread::spawn(move || {
+        actix_rt::System::new().block_on(async {
+            let _ = ctrl_c().await;
+            warn!("Received a stop signal");
+            *kill_signal.lock().unwrap() = true;
+        })
+    });
+
+    prover.keep_up(kill_signal2)
+}

--- a/src/shinigami_bridge.rs
+++ b/src/shinigami_bridge.rs
@@ -5,11 +5,13 @@ use std::sync::Mutex;
 use std::sync::RwLock;
 
 use actix_rt::signal::ctrl_c;
+use clap::Parser;
 use log::info;
 use log::warn;
 
 use crate::block_index::BlocksIndex;
 use crate::chainview;
+use crate::cli::CliArgs;
 use crate::get_chain_provider;
 use crate::init_logger;
 use crate::prover;
@@ -17,6 +19,7 @@ use crate::shinigami_block_storage::JsonBlockFiles;
 use crate::subdir;
 
 pub fn run_bridge() -> anyhow::Result<()> {
+    let cli_options = CliArgs::parse();
     fs::DirBuilder::new()
         .recursive(true)
         .create(subdir(""))
@@ -78,7 +81,16 @@ pub fn run_bridge() -> anyhow::Result<()> {
     // node and save them to disk. It will also create proofs for the blocks
     // and save them to disk.
     let leaf_data = HashMap::new();
-    let mut prover = prover::Prover::new(client, index_store, blocks, view, leaf_data);
+    let mut prover = prover::Prover::new(
+        client,
+        index_store,
+        blocks,
+        view,
+        leaf_data,
+        cli_options.initial_state_path.map(Into::into),
+        cli_options.start_height,
+        cli_options.acc_snapshot_every_n_blocks,
+    );
 
     info!("Starting p2p node");
 

--- a/src/udata.rs
+++ b/src/udata.rs
@@ -284,7 +284,7 @@ pub mod shinigami_udata {
         {
             match self {
                 PoseidonHash::Hash(h) => {
-                    let inner = h.to_raw();
+                    let inner = h.to_fixed_hex_string();
                     inner.serialize(serializer)
                 }
                 PoseidonHash::Placeholder => serializer.serialize_none(),

--- a/src/udata.rs
+++ b/src/udata.rs
@@ -1,97 +1,349 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT
 
-use bitcoin::consensus::Decodable;
-use bitcoin::consensus::Encodable;
 use bitcoin::BlockHash;
-use bitcoin::OutPoint;
-use bitcoin::TxOut;
-use rustreexo::accumulator::node_hash::NodeHash;
-use serde::Deserialize;
-use serde::Serialize;
-use sha2::Digest;
-use sha2::Sha512_256;
+use bitcoin::Script;
+use bitcoin::Txid;
 
-/// Leaf data is the data that is hashed when adding to utreexo state. It contains validation
-/// data and some commitments to make it harder to attack an utreexo-only node.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct LeafData {
-    /// A commitment to the block creating this utxo
+#[derive(Debug, Clone)]
+pub struct LeafContext {
     pub block_hash: BlockHash,
-    /// The utxo's outpoint
-    pub prevout: OutPoint,
-    /// Header code is a compact commitment to the block height and whether or not this
-    /// transaction is coinbase. It's defined as
-    ///
-    /// ```
-    /// header_code: u32 = if transaction.is_coinbase() {
-    ///     (block_height << 1 ) | 1
-    /// } else {
-    ///     block_height << 1
-    /// };
-    /// ```
-    pub header_code: u32,
-    /// The actual utxo
-    pub utxo: TxOut,
+    pub txid: Txid,
+    pub vout: u32,
+    pub value: u64,
+    pub pk_script: Script,
+    pub block_height: u32,
+    pub median_time_past: u32,
+    pub is_coinbase: bool,
 }
 
-/// The version tag to be prepended to the leafhash. It's just the sha512 hash of the string
-/// `UtreexoV1` represented as a vector of [u8] ([85 116 114 101 101 120 111 86 49]).
-/// The same tag is "5574726565786f5631" as a hex string.
-pub const UTREEXO_TAG_V1: [u8; 64] = [
-    0x5b, 0x83, 0x2d, 0xb8, 0xca, 0x26, 0xc2, 0x5b, 0xe1, 0xc5, 0x42, 0xd6, 0xcc, 0xed, 0xdd, 0xa8,
-    0xc1, 0x45, 0x61, 0x5c, 0xff, 0x5c, 0x35, 0x72, 0x7f, 0xb3, 0x46, 0x26, 0x10, 0x80, 0x7e, 0x20,
-    0xae, 0x53, 0x4d, 0xc3, 0xf6, 0x42, 0x99, 0x19, 0x99, 0x31, 0x77, 0x2e, 0x03, 0x78, 0x7d, 0x18,
-    0x15, 0x6e, 0xb3, 0x15, 0x1e, 0x0e, 0xd1, 0xb3, 0x09, 0x8b, 0xdc, 0x84, 0x45, 0x86, 0x18, 0x85,
-];
+#[cfg(not(feature = "shinigami"))]
+pub mod bitcoin_leaf_data {
+    use bitcoin::consensus::Decodable;
+    use bitcoin::consensus::Encodable;
+    use bitcoin::BlockHash;
+    use bitcoin::OutPoint;
+    use bitcoin::TxOut;
+    use rustreexo::accumulator::node_hash::BitcoinNodeHash;
+    use serde::Deserialize;
+    use serde::Serialize;
+    use sha2::Digest;
+    use sha2::Sha512_256;
 
-impl LeafData {
-    pub fn get_leaf_hashes(&self) -> NodeHash {
-        let mut ser_utxo = vec![];
-        let _ = self.utxo.consensus_encode(&mut ser_utxo);
-        let leaf_hash = Sha512_256::new()
-            .chain_update(UTREEXO_TAG_V1)
-            .chain_update(UTREEXO_TAG_V1)
-            .chain_update(self.block_hash)
-            .chain_update(self.prevout.txid)
-            .chain_update(self.prevout.vout.to_le_bytes())
-            .chain_update(self.header_code.to_le_bytes())
-            .chain_update(ser_utxo)
-            .finalize();
-        NodeHash::from(leaf_hash.as_slice())
+    /// Leaf data is the data that is hashed when adding to utreexo state. It contains validation
+    /// data and some commitments to make it harder to attack an utreexo-only node.
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct BitcoinLeafData {
+        /// A commitment to the block creating this utxo
+        pub block_hash: BlockHash,
+        /// The utxo's outpoint
+        pub prevout: OutPoint,
+        /// Header code is a compact commitment to the block height and whether or not this
+        /// transaction is coinbase. It's defined as
+        ///
+        /// ```
+        /// header_code: u32 = if transaction.is_coinbase() {
+        ///     (block_height << 1 ) | 1
+        /// } else {
+        ///     block_height << 1
+        /// };
+        /// ```
+        pub header_code: u32,
+        /// The actual utxo
+        pub utxo: TxOut,
+    }
+
+    /// The version tag to be prepended to the leafhash. It's just the sha512 hash of the string
+    /// `UtreexoV1` represented as a vector of [u8] ([85 116 114 101 101 120 111 86 49]).
+    /// The same tag is "5574726565786f5631" as a hex string.
+    pub const UTREEXO_TAG_V1: [u8; 64] = [
+        0x5b, 0x83, 0x2d, 0xb8, 0xca, 0x26, 0xc2, 0x5b, 0xe1, 0xc5, 0x42, 0xd6, 0xcc, 0xed, 0xdd,
+        0xa8, 0xc1, 0x45, 0x61, 0x5c, 0xff, 0x5c, 0x35, 0x72, 0x7f, 0xb3, 0x46, 0x26, 0x10, 0x80,
+        0x7e, 0x20, 0xae, 0x53, 0x4d, 0xc3, 0xf6, 0x42, 0x99, 0x19, 0x99, 0x31, 0x77, 0x2e, 0x03,
+        0x78, 0x7d, 0x18, 0x15, 0x6e, 0xb3, 0x15, 0x1e, 0x0e, 0xd1, 0xb3, 0x09, 0x8b, 0xdc, 0x84,
+        0x45, 0x86, 0x18, 0x85,
+    ];
+
+    impl BitcoinLeafData {
+        pub fn get_leaf_hashes(&self) -> BitcoinNodeHash {
+            let mut ser_utxo = vec![];
+            let _ = self.utxo.consensus_encode(&mut ser_utxo);
+            let leaf_hash = Sha512_256::new()
+                .chain_update(UTREEXO_TAG_V1)
+                .chain_update(UTREEXO_TAG_V1)
+                .chain_update(self.block_hash)
+                .chain_update(self.prevout.txid)
+                .chain_update(self.prevout.vout.to_le_bytes())
+                .chain_update(self.header_code.to_le_bytes())
+                .chain_update(ser_utxo)
+                .finalize();
+            BitcoinNodeHash::from(leaf_hash.as_slice())
+        }
+    }
+
+    impl Decodable for BitcoinLeafData {
+        fn consensus_decode<R: std::io::Read + ?Sized>(
+            reader: &mut R,
+        ) -> Result<Self, bitcoin::consensus::encode::Error> {
+            Self::consensus_decode_from_finite_reader(reader)
+        }
+        fn consensus_decode_from_finite_reader<R: std::io::Read + ?Sized>(
+            reader: &mut R,
+        ) -> Result<Self, bitcoin::consensus::encode::Error> {
+            let block_hash = BlockHash::consensus_decode(reader)?;
+            let prevout = OutPoint::consensus_decode(reader)?;
+            let header_code = u32::consensus_decode(reader)?;
+            let utxo = TxOut::consensus_decode(reader)?;
+            Ok(BitcoinLeafData {
+                block_hash,
+                prevout,
+                header_code,
+                utxo,
+            })
+        }
+    }
+
+    impl Encodable for BitcoinLeafData {
+        fn consensus_encode<W: std::io::Write + ?Sized>(
+            &self,
+            writer: &mut W,
+        ) -> Result<usize, std::io::Error> {
+            let mut len = 0;
+            len += self.block_hash.consensus_encode(writer)?;
+            len += self.prevout.consensus_encode(writer)?;
+            len += self.header_code.consensus_encode(writer)?;
+            len += self.utxo.consensus_encode(writer)?;
+            Ok(len)
+        }
     }
 }
 
-impl Decodable for LeafData {
-    fn consensus_decode<R: std::io::Read + ?Sized>(
-        reader: &mut R,
-    ) -> Result<Self, bitcoin::consensus::encode::Error> {
-        Self::consensus_decode_from_finite_reader(reader)
+#[cfg(feature = "shinigami")]
+pub mod shinigami_udata {
+    use bitcoin::consensus::Encodable;
+    use bitcoin::Script;
+    use bitcoin::Txid;
+    use bitcoin_hashes::Hash;
+    use rustreexo::accumulator::node_hash::NodeHash;
+    use serde::Serialize;
+    use starknet_crypto::poseidon_hash_many;
+    use starknet_crypto::Felt;
+
+    use super::LeafContext;
+
+    pub struct ByteArray {
+        pub data: Vec<Felt>,
+        pub pending_word: Felt,
+        pub pending_word_len: usize,
     }
-    fn consensus_decode_from_finite_reader<R: std::io::Read + ?Sized>(
-        reader: &mut R,
-    ) -> Result<Self, bitcoin::consensus::encode::Error> {
-        let block_hash = BlockHash::consensus_decode(reader)?;
-        let prevout = OutPoint::consensus_decode(reader)?;
-        let header_code = u32::consensus_decode(reader)?;
-        let utxo = TxOut::consensus_decode(reader)?;
-        Ok(LeafData {
-            block_hash,
-            prevout,
-            header_code,
-            utxo,
-        })
+
+    pub struct ShinigamiLeafData {
+        pub txid: Txid,
+        pub vout: u32,
+        pub value: u64,
+        pub pk_script: ByteArray,
+        pub block_height: u32,
+        pub median_time_past: u32,
+        pub is_coinbase: bool,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    /// We need a stateful wrapper around the actual hash, this is because we use those different
+    /// values inside our accumulator. Here we use an enum to represent the different states, you
+    /// may want to use a struct with more data, depending on your needs.
+    pub enum PoseidonHash {
+        /// This means this holds an actual value
+        ///
+        /// It usually represents a node in the accumulator that haven't been deleted.
+        Hash(Felt),
+        /// Placeholder is a value that haven't been deleted, but we don't have the actual value.
+        /// The only thing that matters about it is that it's not empty. You can implement this
+        /// the way you want, just make sure that [BitcoinNodeHash::is_placeholder] and [NodeHash::placeholder]
+        /// returns sane values (that is, if we call [BitcoinNodeHash::placeholder] calling [NodeHash::is_placeholder]
+        /// on the result should return true).
+        Placeholder,
+        /// This is an empty value, it represents a node that was deleted from the accumulator.
+        ///
+        /// Same as the placeholder, you can implement this the way you want, just make sure that
+        /// [BitcoinNodeHash::is_empty] and [NodeHash::empty] returns sane values.
+        Empty,
+    }
+
+    // you'll need to implement Display for your hash type, so you can print it.
+    impl std::fmt::Display for PoseidonHash {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                PoseidonHash::Hash(h) => write!(f, "Hash({})", h),
+                PoseidonHash::Placeholder => write!(f, "Placeholder"),
+                PoseidonHash::Empty => write!(f, "Empty"),
+            }
+        }
+    }
+
+    // this is the implementation of the BitcoinNodeHash trait for our custom hash type. And it's the only
+    // thing you need to do to use your custom hash type with the accumulator data structures.
+    impl NodeHash for PoseidonHash {
+        // returns a new placeholder type such that is_placeholder returns true
+        fn placeholder() -> Self {
+            PoseidonHash::Placeholder
+        }
+
+        // returns an empty hash such that is_empty returns true
+        fn empty() -> Self {
+            PoseidonHash::Empty
+        }
+
+        // returns true if this is a placeholder. This should be true iff this type was created by
+        // calling placeholder.
+        fn is_placeholder(&self) -> bool {
+            matches!(self, PoseidonHash::Placeholder)
+        }
+
+        // returns true if this is an empty hash. This should be true iff this type was created by
+        // calling empty.
+        fn is_empty(&self) -> bool {
+            matches!(self, PoseidonHash::Empty)
+        }
+
+        // used for serialization, writes the hash to the writer
+        //
+        // if you don't want to use serialization, you can just return an error here.
+        fn write<W>(&self, writer: &mut W) -> std::io::Result<()>
+        where
+            W: std::io::Write,
+        {
+            match self {
+                PoseidonHash::Hash(h) => writer.write_all(&h.to_bytes_be()),
+                PoseidonHash::Placeholder => writer.write_all(&[0u8; 32]),
+                PoseidonHash::Empty => writer.write_all(&[0u8; 32]),
+            }
+        }
+
+        // used for deserialization, reads the hash from the reader
+        //
+        // if you don't want to use serialization, you can just return an error here.
+        fn read<R>(reader: &mut R) -> std::io::Result<Self>
+        where
+            R: std::io::Read,
+        {
+            let mut buf = [0u8; 32];
+            reader.read_exact(&mut buf)?;
+            if buf.iter().all(|&b| b == 0) {
+                Ok(PoseidonHash::Empty)
+            } else {
+                Ok(PoseidonHash::Hash(Felt::from_bytes_be(&buf)))
+            }
+        }
+
+        // the main thing about the hash type, it returns the next node's hash, given it's children.
+        // The implementation of this method is highly consensus critical, so everywhere should use the
+        // exact same algorithm to calculate the next hash. Rustreexo won't call this method, unless
+        // **both** children are not empty.
+        fn parent_hash(left: &Self, right: &Self) -> Self {
+            if let (PoseidonHash::Hash(left), PoseidonHash::Hash(right)) = (left, right) {
+                return PoseidonHash::Hash(poseidon_hash_many(&[*left, *right]));
+            }
+
+            // This should never happen, since rustreexo won't call this method unless both children
+            // are not empty.
+            unreachable!()
+        }
+    }
+
+    impl Serialize for PoseidonHash {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                PoseidonHash::Hash(h) => {
+                    let inner = h.to_raw();
+                    inner.serialize(serializer)
+                }
+                PoseidonHash::Placeholder => serializer.serialize_none(),
+                PoseidonHash::Empty => serializer.serialize_none(),
+            }
+        }
+    }
+
+    impl Encodable for PoseidonHash {
+        fn consensus_encode<W: std::io::Write + ?Sized>(
+            &self,
+            writer: &mut W,
+        ) -> Result<usize, std::io::Error> {
+            match self {
+                PoseidonHash::Hash(h) => {
+                    let inner = h.to_bytes_be();
+                    inner.consensus_encode(writer)
+                }
+                PoseidonHash::Placeholder => Ok(0),
+                PoseidonHash::Empty => Ok(0),
+            }
+        }
+    }
+
+    fn convert_hash256_to_felt(hash: [u8; 32]) -> [Felt; 2] {
+        let (hight, low) = hash.split_at(16);
+
+        [
+            Felt::from_bytes_be_slice(hight),
+            Felt::from_bytes_be_slice(low),
+        ]
+    }
+
+    fn convert_spk_to_byte_array(pk_script: &Script) -> ByteArray {
+        let mut iter = pk_script.as_bytes().chunks_exact(31);
+        let mut data = vec![];
+
+        while let Some(chunk) = iter.next() {
+            let mut word = [0u8; 31];
+            word.copy_from_slice(chunk);
+            data.push(Felt::from_bytes_be_slice(&word));
+        }
+
+        let pending_word = iter.remainder();
+        let pending_word_len = pending_word.len();
+        let pending_word = if pending_word_len > 0 {
+            let mut word = [0u8; 31];
+            word[..pending_word_len].copy_from_slice(pending_word);
+            Felt::from_bytes_be_slice(&word)
+        } else {
+            Felt::from(0u64)
+        };
+
+        ByteArray {
+            data,
+            pending_word,
+            pending_word_len,
+        }
+    }
+
+    impl ShinigamiLeafData {
+        pub fn get_leaf_hashes(data: &LeafContext) -> PoseidonHash {
+            // rouding up to the next multiple of 2
+            let mut data_to_hash = Vec::with_capacity(16);
+            let pk_script = convert_spk_to_byte_array(&data.pk_script);
+            let mut txid = data.txid.as_hash().into_inner();
+            txid.reverse();
+
+            data_to_hash.extend(convert_hash256_to_felt(txid));
+            data_to_hash.push(Felt::from(data.vout));
+            data_to_hash.push(Felt::from(data.value));
+            data_to_hash.extend(pk_script.data);
+            data_to_hash.push(pk_script.pending_word);
+            data_to_hash.push(Felt::from(pk_script.pending_word_len as u64));
+            data_to_hash.push(Felt::from(data.block_height));
+            data_to_hash.push(Felt::from(data.median_time_past));
+            data_to_hash.push(Felt::from(data.is_coinbase as u64));
+
+            let leaf_hash = poseidon_hash_many(&data_to_hash);
+
+            PoseidonHash::Hash(leaf_hash)
+        }
     }
 }
-impl Encodable for LeafData {
-    fn consensus_encode<W: std::io::Write + ?Sized>(
-        &self,
-        writer: &mut W,
-    ) -> Result<usize, std::io::Error> {
-        let mut len = 0;
-        len += self.block_hash.consensus_encode(writer)?;
-        len += self.prevout.consensus_encode(writer)?;
-        len += self.header_code.consensus_encode(writer)?;
-        len += self.utxo.consensus_encode(writer)?;
-        Ok(len)
-    }
-}
+
+#[cfg(not(feature = "shinigami"))]
+pub use bitcoin_leaf_data::BitcoinLeafData as LeafData;
+
+#[cfg(feature = "shinigami")]
+pub use shinigami_udata::ShinigamiLeafData as LeafData;

--- a/src/udata.rs
+++ b/src/udata.rs
@@ -161,7 +161,7 @@ pub mod shinigami_udata {
         pub pending_word: Felt,
         pub pending_word_len: usize,
     }
-    
+
     #[derive(Debug, Clone)]
     #[allow(dead_code)]
     pub struct ShinigamiLeafData {
@@ -321,7 +321,7 @@ pub mod shinigami_udata {
     fn convert_spk_to_byte_array(pk_script: &Script) -> ByteArray {
         let mut iter = pk_script.as_bytes().chunks_exact(31);
         let mut data = vec![];
-        
+
         #[allow(clippy::while_let_on_iterator)]
         while let Some(chunk) = iter.next() {
             let mut word = [0u8; 31];
@@ -364,7 +364,7 @@ pub mod shinigami_udata {
             data_to_hash.push(Felt::from(data.block_height));
             data_to_hash.push(Felt::from(data.median_time_past));
             data_to_hash.push(Felt::from(data.is_coinbase as u64));
-            
+
             let leaf_hash = poseidon_hash_many(&data_to_hash);
 
             PoseidonHash::Hash(leaf_hash)
@@ -381,9 +381,8 @@ pub use shinigami_udata::ShinigamiLeafData as LeafData;
 mod shinigami_tests {
     use starknet_crypto::Felt;
 
-    use crate::udata::shinigami_udata::PoseidonHash;
-
     use super::LeafContext;
+    use crate::udata::shinigami_udata::PoseidonHash;
 
     #[test]
     fn test_node_hash() {
@@ -399,8 +398,11 @@ mod shinigami_tests {
         };
 
         let leaf_hash = super::LeafData::get_leaf_hashes(&leaf);
-        let expected = PoseidonHash::Hash(Felt::from_hex("3945D2584EE5EF0B482B70CD63E0E8CD18827CB348F839D1E6EB8ECBB2B397D").unwrap());
-        
+        let expected = PoseidonHash::Hash(
+            Felt::from_hex("3945D2584EE5EF0B482B70CD63E0E8CD18827CB348F839D1E6EB8ECBB2B397D")
+                .unwrap(),
+        );
+
         assert_eq!(leaf_hash, expected);
     }
 }

--- a/src/udata.rs
+++ b/src/udata.rs
@@ -357,13 +357,14 @@ pub mod shinigami_udata {
             data_to_hash.extend(convert_hash256_to_felt(txid));
             data_to_hash.push(Felt::from(data.vout));
             data_to_hash.push(Felt::from(data.value));
+            data_to_hash.push(Felt::from(pk_script.data.len()));
             data_to_hash.extend(pk_script.data);
             data_to_hash.push(pk_script.pending_word);
             data_to_hash.push(Felt::from(pk_script.pending_word_len as u64));
             data_to_hash.push(Felt::from(data.block_height));
             data_to_hash.push(Felt::from(data.median_time_past));
             data_to_hash.push(Felt::from(data.is_coinbase as u64));
-            println!("{:#?}", data_to_hash);
+            
             let leaf_hash = poseidon_hash_many(&data_to_hash);
 
             PoseidonHash::Hash(leaf_hash)
@@ -378,6 +379,10 @@ pub use shinigami_udata::ShinigamiLeafData as LeafData;
 
 #[cfg(all(feature = "shinigami", test))]
 mod shinigami_tests {
+    use starknet_crypto::Felt;
+
+    use crate::udata::shinigami_udata::PoseidonHash;
+
     use super::LeafContext;
 
     #[test]
@@ -394,6 +399,8 @@ mod shinigami_tests {
         };
 
         let leaf_hash = super::LeafData::get_leaf_hashes(&leaf);
-        println!("Leaf hash: {}", leaf_hash);
+        let expected = PoseidonHash::Hash(Felt::from_hex("3945D2584EE5EF0B482B70CD63E0E8CD18827CB348F839D1E6EB8ECBB2B397D").unwrap());
+        
+        assert_eq!(leaf_hash, expected);
     }
 }


### PR DESCRIPTION
This is the second part of https://github.com/keep-starknet-strange/raito/issues/248

This patch allows our bridge to operate with the starknet bitcoin prover, to achieve this, I made the following changes:

 - We can now use different data serialization and hashes to our accumulator, so we can use their serialization (which contains different data than deafult utreexo) and poseidon as hash function instead of Sha512_256.
 - Make our storage backend generic. We can now save the blocks and proofs in any file format, including json
 - Disable some stuff that we won't use in this case, like the node and API
 - To make experimentation easier, we can now save snapshots of the accumulator and recover from any height 