### PR TITLE
node: fix the worker to better handle connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
 ]
@@ -248,7 +248,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.5.10",
  "time",
  "url",
 ]
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -478,7 +478,7 @@ checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
- "libc 0.2.172",
+ "libc 0.2.174",
  "miniz_oxide",
  "object",
  "rustc-demangle",
@@ -622,6 +622,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +668,7 @@ dependencies = [
  "log",
  "mio",
  "mmap",
+ "rand 0.9.2",
  "reqwest",
  "rustreexo",
  "serde",
@@ -693,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -720,12 +730,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "jobserver",
- "libc 0.2.172",
+ "libc 0.2.174",
  "shlex",
 ]
 
@@ -753,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -763,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -775,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -828,7 +838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.172",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -843,14 +853,14 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
- "libc 0.2.172",
+ "libc 0.2.174",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -1005,7 +1015,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
- "libc 0.2.172",
+ "libc 0.2.174",
  "winapi",
 ]
 
@@ -1130,8 +1140,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "libc 0.2.172",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "libc 0.2.174",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1141,7 +1151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
- "libc 0.2.172",
+ "libc 0.2.174",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
 ]
@@ -1164,9 +1174,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1289,7 +1299,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1328,9 +1338,9 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1352,6 +1362,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -1379,7 +1400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
 dependencies = [
  "cc",
- "libc 0.2.172",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -1389,7 +1410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
 dependencies = [
  "jemalloc-sys",
- "libc 0.2.172",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -1399,7 +1420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
  "getrandom 0.3.3",
- "libc 0.2.172",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -1482,9 +1503,9 @@ checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "local-channel"
@@ -1521,9 +1542,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
@@ -1552,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "minreq"
-version = "2.13.4"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d2aaba477837b46ec1289588180fabfccf0c3b1d1a0c6b1866240cd6cd5ce9"
+checksum = "84885312a86831bff4a3cb04a1e54a3f698407e3274c83249313f194d3e0b678"
 dependencies = [
  "log",
  "serde",
@@ -1567,9 +1588,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
- "libc 0.2.172",
+ "libc 0.2.174",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -1592,7 +1613,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
- "libc 0.2.172",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -1635,7 +1656,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
- "libc 0.2.172",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -1694,7 +1715,7 @@ checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if",
  "instant",
- "libc 0.2.172",
+ "libc 0.2.174",
  "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
@@ -1707,8 +1728,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
- "libc 0.2.172",
- "redox_syscall 0.5.12",
+ "libc 0.2.174",
+ "redox_syscall 0.5.17",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1784,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1795,7 +1816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc 0.2.172",
+ "libc 0.2.174",
  "rand_core 0.3.1",
  "rdrand",
  "winapi",
@@ -1807,9 +1828,19 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc 0.2.172",
- "rand_chacha",
+ "libc 0.2.174",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1820,6 +1851,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1847,6 +1888,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -1977,16 +2027,16 @@ dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.16",
- "libc 0.2.172",
+ "libc 0.2.174",
  "untrusted",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc_version"
@@ -2115,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -2177,11 +2227,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
- "libc 0.2.172",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -2203,12 +2253,9 @@ checksum = "c4e36eca171fddeda53901b0a436573b3f2391eaa9189d439b2bd8ea8cebd7e3"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "sled"
@@ -2221,7 +2268,7 @@ dependencies = [
  "crossbeam-utils",
  "fs2",
  "fxhash",
- "libc 0.2.172",
+ "libc 0.2.174",
  "log",
  "parking_lot 0.11.2",
 ]
@@ -2238,8 +2285,18 @@ version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
- "libc 0.2.172",
+ "libc 0.2.174",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc 0.2.174",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2272,10 +2329,12 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4037bcb26ce7c508448d221e570d075196fd4f6912ae6380981098937af9522a"
+checksum = "87af771d7f577931913089f9ca9a9f85d8a6238d59b2977f4c383d133c8abd3b"
 dependencies = [
+ "blake2",
+ "digest",
  "lambdaworks-crypto",
  "lambdaworks-math",
  "num-bigint",
@@ -2300,9 +2359,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2333,7 +2392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.172",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -2383,7 +2442,7 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
- "libc 0.2.172",
+ "libc 0.2.174",
  "num-conv",
  "num_threads",
  "powerfmt",
@@ -2425,19 +2484,21 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
- "libc 0.2.172",
+ "io-uring",
+ "libc 0.2.174",
  "mio",
  "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
- "windows-sys 0.52.0",
+ "slab",
+ "socket2 0.6.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2452,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2587,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -2887,18 +2948,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ actix-http = "=3.9.0"
 derive_more = "=0.99.18"
 idna = "=0.5.0"
 url = "=2.5.2"
+rand = "0.9.2"
 
 [features]
 default = ["bitcoin", "node", "api"]

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,55 +1,40 @@
 //SPDX-License-Identifier: MIT
 
-/// A simple and efficient implementation of Bitcoin P2P network
-///
-/// This bridge software gives you the option to serve proofs and blocks over the
-/// p2p port, just like any other node. The way it works is simple and meant to use
-/// as little deps as possible. We explicitly don't use async/await on this.
-///
-/// ## Architecture
-///
-/// This implementation uses async IO, but without the overhead of proper async/await.
-/// It is broken down in three modules: [Reactor], [Worker] and [Peer].
-///   - [Reactor]: We only have one of those, it will run in a loop, polling different sockets for events. If
-///                the socket gets ready for read/write, the reactor should send the socket
-///                and ID to one of our workers. The worker selection is random and assumes
-///                that they will take about the same time to handle each socket. In the future
-///                we may need to add a proper work distribution mechanism.
-///
-///   - [Worker]: We have a couple of workers, and each worker has one OS thread. When a socket is
-///               ready, one [Worker] will receive it using a channel. The actual [Peer] state is
-///               kept inside our workers, inside a shared vector. So, after receiver a notification,
-///               we pick the corresponding [Peer] and call `handle_request` to read from the socket
-///               and handle the request. `handle_request` don't write to the socket, only to a
-///               buffer. If needed, the worker will also write back that data.
-///
-///   - [Peer]: Holds all the context related to a [Peer] and handles requests. Since we may not
-///             read a hole [NetworkMessage] at once (or read more than one), we buffer everything
-///             in a read buffer. We also have a write buffer, and this is to both avoid too many
-///             syscalls, but also to avoid calling write too often, which should cause the socket
-///             to err on `WouldBlock`. If we don't succeed in sending all the buffer, the [Worker]
-///             will schedule us for write events (we won't read before finishing the write).
-use std::cell::UnsafeCell;
-use std::collections::BTreeMap;
+//! A simple and efficient implementation of Bitcoin P2P network
+//!
+//! This bridge software gives you the option to serve proofs and blocks over the
+//! p2p port, just like any other node. The way it works is simple and meant to use
+//! as little deps as possible. We explicitly don't use async/await on this.
+//!
+//! ## Architecture
+//!
+//! This implementation uses async IO, but without the overhead of proper async/await.
+//! It is broken down in three modules: [Acceptor], [Worker] and [Peer].
+//! The [Acceptor] is responsible for accepting new connections and notifying the workers about
+//! them.
+//! The [Worker] is responsible for processing the requests and sending responses back to the
+//! peers. It has an internal reactor that polls for events on the sockets it is watching, handles
+//! them and sends the relevant messages to the [Peer].
+//! A [Peer] holds the inner state of a connection, and is responsible for reading requests,
+//! writing responses and handling the protocol. It has a read buffer and a write buffer,
+//! and it uses them to read requests and write responses.
+
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::io::Read;
 use std::io::Write;
 use std::net::SocketAddr;
-use std::rc::Rc;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::sync::PoisonError;
 use std::sync::RwLock;
 use std::time::Duration;
-use std::time::Instant;
 
 use bitcoin::consensus::deserialize;
 use bitcoin::consensus::serialize;
 use bitcoin::consensus::Decodable;
 use bitcoin::hashes::Hash;
-use bitcoin::key::rand::random;
 use bitcoin::p2p::message::NetworkMessage;
 use bitcoin::p2p::message::RawNetworkMessage;
 use bitcoin::p2p::message_blockdata::Inventory;
@@ -59,10 +44,10 @@ use bitcoin::p2p::Magic;
 use bitcoin::p2p::ServiceFlags;
 use bitcoin::BlockHash;
 use log::debug;
-use log::error;
 use log::info;
 use mio::net::TcpListener;
 use mio::net::TcpStream;
+use mio::Events;
 use sha2::Digest;
 use sha2::Sha256;
 
@@ -70,7 +55,10 @@ use crate::block_index::BlocksIndex;
 use crate::blockfile::BlockFile;
 use crate::chainview::ChainView;
 
-const FILTER_TYPE_UTREEXO: u8 = 1;
+/// DEPRECATED: This is a constant that defines the filter type for Utreexo
+pub const FILTER_TYPE_UTREEXO: u8 = 1;
+
+/// How many workers we want to spawn
 const WORKES_PER_CLUSTER: usize = 4;
 
 #[derive(Debug)]
@@ -85,10 +73,13 @@ pub struct P2PMessageHeader {
     /// This constant is defined per-network, and if it doesn't match what we expected, we'll
     /// disconnect with that peer
     _magic: Magic,
+
     /// A command string telling what this message should be (e.g.: block, inv, tx)
     _command: [u8; 12],
+
     /// How long this message is
     length: u32,
+
     /// The payload's checksum
     _checksum: u32,
 }
@@ -98,10 +89,13 @@ pub struct P2PMessageHeader {
 pub struct WorkerContext {
     /// The actual blocks and proofs
     pub proof_backend: Arc<RwLock<BlockFile>>,
+
     /// An index on [BlockFile] so we can get specific blocks
     pub proof_index: Arc<BlocksIndex>,
+
     /// Our chain metadata. Things like our height, and  an index height -> hash
     pub chainview: Arc<ChainView>,
+
     /// The magic bits for the network we are on
     pub magic: Magic,
 }
@@ -124,8 +118,262 @@ impl Decodable for P2PMessageHeader {
 }
 
 /// A struct that will set everything up and running. It doesn't have any state nor runs on any
-/// thread, but after calling `run` you should have the [Reactor] and [Worker]s running
+/// thread, but after calling `run` you should have everything set.
 pub struct Node;
+
+impl Node {
+    /// Spawn a reactor and some workers to handle requests.
+    ///
+    /// If we can't set things up, this function will panic
+    pub fn run(
+        address: SocketAddr,
+        worker_context: WorkerContext,
+        block_notifier: Receiver<BlockHash>,
+    ) {
+        let listener = TcpListener::bind(address).expect("Failed to bind to address");
+        let reactor = Acceptor {
+            block_notifier,
+            listener,
+            worker_pool: Self::create_workers(&worker_context),
+        };
+
+        std::thread::Builder::new()
+            .name("bridge - acceptor thread".to_string())
+            .spawn(move || reactor.run())
+            .expect("Failed to spawn reactor");
+    }
+
+    /// spawns our workers
+    fn create_workers(worker_context: &WorkerContext) -> [Sender<Message>; WORKES_PER_CLUSTER] {
+        let mut workers = Vec::new();
+        for i in 0..WORKES_PER_CLUSTER {
+            let (tx, rx) = std::sync::mpsc::channel();
+            let worker = Worker::new(i, worker_context.clone(), rx);
+
+            std::thread::Builder::new()
+                .name(format!("bridge - worker {}", i))
+                .spawn(move || worker.run())
+                .expect("Failed to spawn worker");
+
+            workers.push(tx);
+        }
+
+        workers.try_into().expect("Failed to create workers")
+    }
+}
+
+#[derive(Debug)]
+/// Messages sent from [Reactor] to [Worker]
+pub enum Message {
+    /// The server got a new connection
+    ///
+    /// Once a worker gets this, it'll construct a [Peer] struct and schedule it for the next
+    /// message
+    NewConnection(TcpStream),
+
+    NewBlock(BlockHash),
+}
+
+/// A struct that will run and wait for work to do. Once it gets a new work from [Reactor], it will
+/// call the relevant functions and use its cpu share to make progress
+struct Worker {
+    /// A unique per-worker identifier
+    id: usize,
+
+    /// A channel to receive messages from the [Acceptor]
+    ///
+    /// We use it to tell about new connections and new blocks. The worker will
+    /// process those messages and notify the relevant [Peer]s
+    peer_receiver: Receiver<Message>,
+
+    /// A map of all the peers we are watching
+    peers: HashMap<usize, (TcpStream, Peer)>,
+
+    /// We use those to build [Peer]
+    context: WorkerContext,
+
+    /// A mio poller to watch for events
+    ///
+    /// Each worker has a local reactor, that keeps polling for events on the sockets
+    /// it is watching. Connections are sent from the [Acceptor] to a random worker,
+    /// that should then follow it for as long as it is alive.
+    pooler: mio::Poll,
+
+    /// A counter to assign unique IDs to each peer
+    id_count: usize,
+}
+
+impl Worker {
+    /// Creates a new worker
+    ///
+    /// This function doesn't spawn any thread, the caller is responsible for running [Worker::run]
+    /// inside a thread
+    fn new(id: usize, context: WorkerContext, peer_receiver: Receiver<Message>) -> Self {
+        Self {
+            peers: HashMap::new(),
+            id,
+            context,
+            peer_receiver,
+            pooler: mio::Poll::new().expect("can't create a mio Poller"),
+            id_count: 0,
+        }
+    }
+
+    fn run(mut self) {
+        loop {
+            if let Ok(message) = self.peer_receiver.try_recv() {
+                match message {
+                    Message::NewConnection(socket) => {
+                        debug!("worker {}: got a new peer to watch", self.id);
+                        self.handle_new_peer(socket);
+                        self.id_count += 1;
+                    }
+
+                    Message::NewBlock(block_hash) => {
+                        debug!(
+                            "worker {}: got a new block notification: {}",
+                            self.id, block_hash
+                        );
+                        let block_msg =
+                            NetworkMessage::Inv(vec![Inventory::WitnessBlock(block_hash)]);
+                        // Notify all peers about the new block
+                        for (_, (_, peer)) in self.peers.iter_mut() {
+                            if let Err(e) = peer.send_message(block_msg.clone()) {
+                                log::error!("Failed to send new block to peer: {}", e);
+                            }
+                        }
+                    }
+                }
+            }
+
+            self.handle_peers();
+        }
+    }
+
+    fn handle_new_peer(&mut self, mut stream: TcpStream) {
+        debug!("worker {}: got a new peer to watch", self.id);
+
+        let token = mio::Token(self.id_count);
+        self.pooler
+            .registry()
+            .register(
+                &mut stream,
+                token,
+                mio::Interest::READABLE | mio::Interest::WRITABLE,
+            )
+            .expect("Failed to register socket");
+
+        let peer = Peer::new(self.context.clone());
+
+        self.peers.insert(token.0, (stream, peer));
+    }
+
+    /// Takes ownership of the worker and runs until this thread dies
+    fn handle_peers(&mut self) {
+        let mut events = Events::with_capacity(1024);
+
+        self.pooler
+            .poll(&mut events, Some(Duration::from_secs(1)))
+            .expect("Failed to poll events");
+
+        for event in events.iter() {
+            let token = event.token();
+            let (stream, peer) = self.peers.get_mut(&token.0).unwrap();
+
+            if event.is_readable() {
+                debug!("worker {}: got read event for peer {}", self.id, token.0);
+                if let Err(err) = peer.handle_request(stream) {
+                    log::error!("Error handling request: {}", err);
+                    if let PeerError::Io(ref e) = err {
+                        if e.kind() == std::io::ErrorKind::WouldBlock {
+                            continue;
+                        }
+                    }
+
+                    self.peers.remove(&token.0);
+                    continue;
+                }
+            }
+
+            if event.is_writable() {
+                match peer.write_back(stream) {
+                    Err(err) => {
+                        log::error!("Error handling request: {}", err);
+                        if let PeerError::Io(ref e) = err {
+                            if e.kind() == std::io::ErrorKind::WouldBlock {
+                                continue;
+                            }
+                        }
+
+                        self.peers.remove(&token.0);
+                        continue;
+                    }
+
+                    Ok(_) => continue,
+                }
+            }
+        }
+    }
+}
+
+/// Keep watching sockets for new connections
+struct Acceptor {
+    /// Our server's listener
+    ///
+    /// Used to accept new p2p connections
+    listener: TcpListener,
+
+    /// Channels to our workers
+    worker_pool: [Sender<Message>; WORKES_PER_CLUSTER],
+
+    /// A channel to notify us about new blocks
+    block_notifier: Receiver<BlockHash>,
+}
+
+impl Acceptor {
+    fn run(mut self) {
+        let mut poll = mio::Poll::new().expect("can't create a mio Poller");
+        poll.registry()
+            .register(&mut self.listener, mio::Token(0), mio::Interest::READABLE)
+            .expect("Failed to register listener");
+
+        let mut events = mio::Events::with_capacity(1024);
+        loop {
+            poll.poll(&mut events, Some(Duration::from_secs(1)))
+                .expect("Failed to poll events");
+
+            for event in events.iter() {
+                match event.token() {
+                    mio::Token(0) => {
+                        debug!("acceptor: our listener got a new event");
+
+                        let Ok((stream, address)) = self.listener.accept() else {
+                            log::error!("Failed to accept connection");
+                            continue;
+                        };
+                        let worker = rand::random::<u32>() as usize % WORKES_PER_CLUSTER;
+                        info!("acceptor: saw new connection from {address}, sending to worker {worker}");
+                        self.worker_pool[worker]
+                            .send(Message::NewConnection(stream))
+                            .expect("Failed to send new connection to worker");
+                    }
+
+                    _ => {}
+                }
+            }
+
+            // Check for new blocks and notify workers
+            if let Ok(block_hash) = self.block_notifier.try_recv() {
+                debug!("acceptor: got new block notification: {}", block_hash);
+                for worker in &self.worker_pool {
+                    worker
+                        .send(Message::NewBlock(block_hash.clone()))
+                        .expect("Failed to send new block to worker");
+                }
+            }
+        }
+    }
+}
 
 /// Local context for each peer
 ///
@@ -134,16 +382,12 @@ pub struct Node;
 pub struct Peer {
     /// Data that we've read, but didn't process
     read_buffer: Vec<u8>,
+
     /// Data that we need to write into the socket
     write_buffer: Vec<u8>,
-    /// Where we can get blocks to send to peers
-    proof_backend: Arc<RwLock<BlockFile>>,
-    /// Index to learn where things are inside the [BlockFile]
-    proof_index: Arc<BlocksIndex>,
-    /// General info about our chain
-    chainview: Arc<ChainView>,
-    /// Magic bits used in every network message
-    magic: Magic,
+
+    /// The context
+    context: WorkerContext,
 }
 
 #[derive(Debug)]
@@ -151,12 +395,16 @@ pub struct Peer {
 enum PeerError {
     /// Io Error
     Io(std::io::Error),
+
     /// Can't decode the message
     Decode(bitcoin::consensus::encode::Error),
+
     /// Some lock is poisoned (a thread died while holding it)
     Poison,
+
     /// The provided magic value is invalid
     InvalidMagic,
+
     /// The message we got is too big
     MessageTooLarge,
 }
@@ -191,489 +439,10 @@ impl<T> From<PoisonError<T>> for PeerError {
     }
 }
 
-impl Node {
-    /// Spawn a reactor and some workers to handle requests.
-    ///
-    /// If we can't set things up, this function will panic
-    pub fn run(
-        address: SocketAddr,
-        worker_context: WorkerContext,
-        block_notifier: Receiver<BlockHash>,
-    ) {
-        let listener = TcpListener::bind(address).expect("Failed to bind to address");
-        let (register, register_rx) = std::sync::mpsc::channel();
-        let reactor = Reactor {
-            block_notifier,
-            listener,
-            registered: HashMap::new(),
-            register: register_rx,
-            worker_pool: Self::create_workers(&worker_context, register),
-            magic: worker_context.magic,
-            pings: BTreeMap::new(),
-            timeouts: BTreeMap::new(),
-        };
-
-        std::thread::Builder::new()
-            .name("bridge - reactor thread".to_string())
-            .spawn(move || reactor.run())
-            .expect("Failed to spawn reactor");
-    }
-
-    /// spawns our workers
-    fn create_workers(
-        worker_context: &WorkerContext,
-        scheduler: Sender<(usize, TcpStream, Intent)>,
-    ) -> [Sender<Message>; WORKES_PER_CLUSTER] {
-        let mut workers = Vec::new();
-        let peers = Rc::new(UnsafeCell::new(HashMap::new()));
-        for i in 0..WORKES_PER_CLUSTER {
-            let (tx, rx) = std::sync::mpsc::channel();
-            let worker = Worker::new(
-                i,
-                peers.clone(),
-                worker_context.proof_backend.clone(),
-                worker_context.proof_index.clone(),
-                worker_context.chainview.clone(),
-                worker_context.magic,
-                rx,
-                scheduler.clone(),
-            );
-
-            std::thread::Builder::new()
-                .name(format!("bridge - worker {}", i))
-                .spawn(move || worker.run())
-                .expect("Failed to spawn worker");
-
-            workers.push(tx);
-        }
-
-        workers.try_into().expect("Failed to create workers")
-    }
-}
-
-#[derive(Debug)]
-/// Messages sent from [Reactor] to [Worker]
-pub enum Message {
-    /// The server got a new connection
-    ///
-    /// Once a worker gets this, it'll construct a [Peer] struct and schedule it for the next
-    /// message
-    NewConnection(TcpStream),
-    /// There's something to read in the socket
-    ReadReady((TcpStream, usize)),
-    /// We can write to the socket
-    WriteReady((TcpStream, usize)),
-    /// Some peer disconnected (either them or us killed the socket)
-    Disconnect(usize),
-}
-
-#[derive(Debug)]
-/// What are we waiting for
-enum Intent {
-    Read,
-    Write,
-}
-
-/// A struct that will run and wait for work to do. Once it gets a new work from [Reactor], it will
-/// call the relevant functions and use its cpu share to make progress
-struct Worker {
-    /// A unique per-worker identifier
-    id: usize,
-    /// The channel used by [Reactor] to notify us about new things to do
-    job_receiver: Receiver<Message>,
-    /// A shared memory region that holds all our [Peer]s
-    ///
-    /// Since we know that never two workers will try to operate on the same [Peer], and also that
-    /// all changes to the actual [HashMap] will always be made by worker `0` (see the reactor
-    /// bellow). We don't need to worry about synchronization here. Moreover, we'll never drop
-    /// this, as our workers lives through the entire lifetime of our program, we don't need an
-    /// [Arc].
-    peers: Rc<UnsafeCell<HashMap<usize, Peer>>>,
-    /// A channel to ask the [Reactor] to notify us about new events
-    scheduler: Sender<(usize, TcpStream, Intent)>,
-
-    /// We use those to build [Peer]
-    proof_backend: Arc<RwLock<BlockFile>>,
-    proof_index: Arc<BlocksIndex>,
-    chainview: Arc<ChainView>,
-    magic: Magic,
-}
-
-unsafe impl Sync for Worker {}
-unsafe impl Send for Worker {}
-
-impl Worker {
-    /// Creates a new worker
-    ///
-    /// This function doesn't spawn any thread, the caller is responsible for running [Worker::run]
-    /// inside a thread
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        id: usize,
-        peers: Rc<UnsafeCell<HashMap<usize, Peer>>>,
-        proof_backend: Arc<RwLock<BlockFile>>,
-        proof_index: Arc<BlocksIndex>,
-        chainview: Arc<ChainView>,
-        magic: Magic,
-        job_receiver: Receiver<Message>,
-        scheduler: Sender<(usize, TcpStream, Intent)>,
-    ) -> Self {
-        Self {
-            peers,
-            scheduler,
-            id,
-            proof_backend,
-            proof_index,
-            chainview,
-            magic,
-            job_receiver,
-        }
-    }
-
-    /// Takes ownership of the worker and runs until this thread dies
-    fn run(self) {
-        debug!("Worker {} started", self.id);
-        loop {
-            let job = self
-                .job_receiver
-                .recv()
-                .expect("job_receiver channel is broken");
-
-            match job {
-                Message::NewConnection(socket) => {
-                    let peer = Peer::new(
-                        "unknown".to_string(),
-                        "unknown".to_string(),
-                        self.proof_backend.clone(),
-                        self.proof_index.clone(),
-                        self.chainview.clone(),
-                        self.magic,
-                    );
-
-                    let id: usize = random();
-                    let peers = unsafe { &mut *self.peers.get() };
-
-                    peers.insert(id, peer);
-                    self.scheduler
-                        .send((id, socket, Intent::Read))
-                        .expect("reactor died");
-                }
-
-                Message::ReadReady((mut stream, id)) => {
-                    debug!("worker: got read event for peer {id}");
-
-                    let peers = unsafe { &mut *self.peers.get() };
-                    let Some(peer) = peers.get_mut(&id) else {
-                        log::error!("can't find peer: {id}");
-                        peers.remove(&id);
-                        continue;
-                    };
-
-                    if let Err(err) = peer.handle_request(&mut stream) {
-                        log::error!("Error handling request: {}", err);
-                        if let PeerError::Io(ref e) = err {
-                            if e.kind() == std::io::ErrorKind::WouldBlock {
-                                self.scheduler
-                                    .send((id, stream, Intent::Read))
-                                    .expect("reactor died");
-
-                                continue;
-                            }
-                        }
-
-                        peers.remove(&id);
-                        continue;
-                    }
-
-                    match peer.write_back(&mut stream) {
-                        Ok(true) => self
-                            .scheduler
-                            .send((id, stream, Intent::Read))
-                            .expect("reactor died"),
-
-                        Ok(false) => self
-                            .scheduler
-                            .send((id, stream, Intent::Write))
-                            .expect("reactor died"),
-
-                        Err(err) => {
-                            log::error!("Error handling request: {}", err);
-                            if let PeerError::Io(ref e) = err {
-                                if e.kind() == std::io::ErrorKind::WouldBlock {
-                                    self.scheduler
-                                        .send((id, stream, Intent::Write))
-                                        .expect("reactor died");
-                                    continue;
-                                }
-                            }
-
-                            peers.remove(&id);
-                            continue;
-                        }
-                    }
-                }
-
-                Message::WriteReady((mut stream, id)) => {
-                    debug!("worker: got event for peer {id}");
-
-                    let peers = unsafe { &mut *self.peers.get() };
-                    let Some(peer) = peers.get_mut(&id) else {
-                        log::error!("can't find peer: {id}");
-                        peers.remove(&id);
-                        continue;
-                    };
-
-                    match peer.write_back(&mut stream) {
-                        Ok(true) => self
-                            .scheduler
-                            .send((id, stream, Intent::Read))
-                            .expect("reactor died"),
-
-                        Ok(false) => self
-                            .scheduler
-                            .send((id, stream, Intent::Write))
-                            .expect("reactor died"),
-
-                        Err(err) => {
-                            log::error!("Error handling request: {}", err);
-                            if let PeerError::Io(ref e) = err {
-                                if e.kind() == std::io::ErrorKind::WouldBlock {
-                                    self.scheduler
-                                        .send((id, stream, Intent::Write))
-                                        .expect("reactor died");
-                                    continue;
-                                }
-                            }
-
-                            peers.remove(&id);
-                            continue;
-                        }
-                    }
-                }
-
-                Message::Disconnect(id) => {
-                    info!("worker: peer {id} disconnected");
-
-                    let peers = unsafe { &mut *self.peers.get() };
-                    peers.remove(&id);
-                }
-            }
-        }
-    }
-}
-
-/// Keep watching sockets for new events
-struct Reactor {
-    /// Our server's listener
-    ///
-    /// Used to accept new p2p connections
-    listener: TcpListener,
-    /// Channels to our workers
-    worker_pool: [Sender<Message>; WORKES_PER_CLUSTER],
-    /// A channel we use to receive things to watch
-    register: Receiver<(usize, TcpStream, Intent)>,
-    /// Sockets we are watching
-    registered: HashMap<usize, (TcpStream, Intent)>,
-    /// This channel will notify us about new blocks
-    block_notifier: Receiver<BlockHash>,
-    /// Magic value for this network
-    magic: Magic,
-    /// If a peer doesn't send us a message for too long, poke it to see if it's still alive
-    timeouts: BTreeMap<Instant, usize>,
-    /// pings we've sent
-    pings: BTreeMap<Instant, usize>,
-}
-
-impl Reactor {
-    fn run(mut self) {
-        let mut poll = mio::Poll::new().expect("can't create a mio Poller");
-        poll.registry()
-            .register(&mut self.listener, mio::Token(0), mio::Interest::READABLE)
-            .expect("Failed to register listener");
-
-        let mut events = mio::Events::with_capacity(1024);
-        loop {
-            let registry = poll.registry();
-            while let Ok(mut work) = self.register.try_recv() {
-                debug!("reactor: registering {} for {:?}", work.0, work.2);
-
-                self.timeouts
-                    .insert(Instant::now() + Duration::from_secs(10 * 60), work.0);
-
-                let intent = match work.2 {
-                    Intent::Read => mio::Interest::READABLE,
-                    Intent::Write => mio::Interest::WRITABLE,
-                };
-
-                match registry.register(&mut work.1, mio::Token(work.0), intent) {
-                    Ok(_) => {}
-                    Err(e) => {
-                        log::error!("Failed to register socket: {}", e);
-                        continue;
-                    }
-                }
-
-                self.registered.insert(work.0, (work.1, work.2));
-            }
-
-            let next_timeout = self
-                .timeouts
-                .iter()
-                .next()
-                .map(|(t, _)| t.duration_since(Instant::now()));
-
-            if let Err(e) = poll.poll(
-                &mut events,
-                Some(next_timeout.unwrap_or(Duration::from_secs(1))),
-            ) {
-                log::error!("Failed to poll: {}", e);
-                continue;
-            }
-
-            self.block_notifier.try_iter().for_each(|block| {
-                let inv = RawNetworkMessage::new(
-                    self.magic,
-                    NetworkMessage::Inv(vec![Inventory::Block(block)]),
-                );
-
-                let msg = serialize(&inv);
-
-                self.registered.iter_mut().for_each(|(_, (socket, _))| {
-                    let _ = socket.write_all(&msg);
-                });
-            });
-
-            let registry = poll.registry();
-            for event in events.iter() {
-                match event.token() {
-                    mio::Token(0) => {
-                        debug!("reactor: our listener got a new event");
-
-                        let Ok((stream, address)) = self.listener.accept() else {
-                            log::error!("Failed to accept connection");
-                            continue;
-                        };
-
-                        info!("reactor: saw new connection from {address}");
-
-                        self.worker_pool[0]
-                            .send(Message::NewConnection(stream))
-                            .expect("Failed to send new connection to worker");
-                    }
-
-                    mio::Token(token) => {
-                        debug!("reactor: event for {token}");
-
-                        if event.is_read_closed() || event.is_write_closed() || event.is_error() {
-                            let (mut socket, _) = self
-                                .registered
-                                .remove(&token)
-                                .expect("BUG: socket is registered but not in registered map");
-
-                            if let Err(e) = registry.deregister(&mut socket) {
-                                error!("can't deregister socket {token} due to {e:?}");
-                                continue;
-                            }
-
-                            self.pings.retain(|_, id| id != &token);
-                            self.timeouts.retain(|_, id| id != &token);
-                            self.worker_pool[0]
-                                .send(Message::Disconnect(token))
-                                .expect("Failed to send disconnect to worker");
-                            continue;
-                        }
-
-                        let worker_id = random::<usize>() % self.worker_pool.len();
-                        let worker = self.worker_pool.get(worker_id).expect("broken worker");
-                        let (mut socket, intent) = self
-                            .registered
-                            .remove(&token)
-                            .expect("BUG: socket is registered but not in registered map");
-
-                        if let Err(e) = registry.deregister(&mut socket) {
-                            error!("can't deregister socket {token} due to {e:?}");
-                            continue;
-                        }
-
-                        self.pings.retain(|_, id| id != &token);
-                        self.timeouts.retain(|_, id| id != &token);
-
-                        debug!("reactor: sending job to worker {}", worker_id);
-                        match intent {
-                            Intent::Read => {
-                                worker
-                                    .send(Message::ReadReady((socket, token)))
-                                    .expect("Failed to send to worker");
-                            }
-                            Intent::Write => {
-                                worker
-                                    .send(Message::WriteReady((socket, token)))
-                                    .expect("Failed to send to worker");
-                            }
-                        }
-                    }
-                }
-            }
-
-            let now = Instant::now();
-            let new_timeout = self.timeouts.split_off(&now);
-
-            for (_, id) in self.timeouts {
-                debug!("reactor: sending ping to {id}");
-                let nonce = random();
-                let ping = RawNetworkMessage::new(self.magic, NetworkMessage::Ping(nonce));
-
-                let msg = serialize(&ping);
-                let (socket, _) = self
-                    .registered
-                    .get_mut(&id)
-                    .expect("BUG: socket is registered but not in registered map");
-
-                match socket.write_all(&msg) {
-                    Ok(_) => {
-                        self.pings.insert(now + Duration::from_secs(30), id);
-                    }
-                    Err(e) => {
-                        log::error!("Failed to send ping: {}", e);
-                        self.registered.remove(&id);
-                        self.worker_pool[0]
-                            .send(Message::Disconnect(id))
-                            .expect("Failed to send disconnect to worker");
-                        continue;
-                    }
-                }
-            }
-
-            self.timeouts = new_timeout;
-            for (time, id) in self.pings.iter() {
-                // request timed out, assume peer died
-                if *time < now {
-                    debug!("reactor: peer {id} timed out ping");
-
-                    self.worker_pool[0]
-                        .send(Message::Disconnect(*id))
-                        .expect("Failed to send disconnect to worker");
-                    self.registered.remove(id);
-                }
-            }
-        }
-    }
-}
-
 impl Peer {
-    pub fn new(
-        _peer: String,
-        _peer_id: String,
-        proof_backend: Arc<RwLock<BlockFile>>,
-        proof_index: Arc<BlocksIndex>,
-        chainview: Arc<ChainView>,
-        magic: Magic,
-    ) -> Self {
+    pub fn new(context: WorkerContext) -> Self {
         Self {
-            proof_backend,
-            proof_index,
-            chainview,
-            magic,
+            context,
             write_buffer: Vec::new(),
             read_buffer: Vec::new(),
         }
@@ -686,7 +455,7 @@ impl Peer {
             return Err(PeerError::MessageTooLarge);
         }
 
-        if header._magic != self.magic {
+        if header._magic != self.context.magic {
             return Err(PeerError::InvalidMagic);
         }
 
@@ -700,14 +469,14 @@ impl Peer {
     }
 
     fn send_message(&mut self, message: NetworkMessage) -> Result<(), PeerError> {
-        let msg = RawNetworkMessage::new(self.magic, message);
+        let msg = RawNetworkMessage::new(self.context.magic, message);
         self.write_buffer.extend(&serialize(&msg));
 
         Ok(())
     }
 
     fn read_pending(&mut self, stream: &mut TcpStream) -> Result<usize, PeerError> {
-        let mut buffer = vec![0; 32_000_000];
+        let mut buffer = vec![0; 4_000_000];
         let read = stream.read(&mut buffer)?;
 
         self.read_buffer.extend(buffer.drain(0..read));
@@ -772,7 +541,7 @@ impl Peer {
                                 continue;
                             }
                             let block_hash = BlockHash::from_byte_array(*hash);
-                            let Some(block) = self.proof_index.get_index(block_hash) else {
+                            let Some(block) = self.context.proof_index.get_index(block_hash) else {
                                 let not_found =
                                     NetworkMessage::NotFound(vec![Inventory::Unknown {
                                         inv_type: 0x41000002,
@@ -783,7 +552,7 @@ impl Peer {
                                 continue;
                             };
 
-                            let lock = self.proof_backend.read()?;
+                            let lock = self.context.proof_backend.read()?;
                             let payload = lock.get_block_slice(block);
                             let checksum = &self.sha256d_payload(payload)[0..4];
 
@@ -798,7 +567,8 @@ impl Peer {
                             stream.write_all(payload)?;
                         }
                         Inventory::WitnessBlock(block_hash) => {
-                            let Some(block) = self.proof_index.get_index(*block_hash) else {
+                            let Some(block) = self.context.proof_index.get_index(*block_hash)
+                            else {
                                 let not_found =
                                     NetworkMessage::NotFound(vec![Inventory::WitnessBlock(
                                         *block_hash,
@@ -806,7 +576,7 @@ impl Peer {
                                 self.send_message(not_found)?;
                                 continue;
                             };
-                            let lock = self.proof_backend.read().expect("lock failed");
+                            let lock = self.context.proof_backend.read().expect("lock failed");
                             match lock.get_block(block) {
                                 //TODO: Rust-Bitcoin asks for a block, but we have it serialized on disk already.
                                 //      We should be able to just send the block without deserializing it.
@@ -841,15 +611,20 @@ impl Peer {
                     return Ok(());
                 };
 
-                let height = self.chainview.get_height(*block).unwrap().unwrap_or(0);
+                let height = self
+                    .context
+                    .chainview
+                    .get_height(*block)
+                    .unwrap()
+                    .unwrap_or(0);
 
                 let height = height + 1;
                 for h in height..(height + 2_000) {
-                    let Ok(Some(block_hash)) = self.chainview.get_block_hash(h) else {
+                    let Ok(Some(block_hash)) = self.context.chainview.get_block_hash(h) else {
                         break;
                     };
 
-                    let Ok(Some(header_info)) = self.chainview.get_block(block_hash) else {
+                    let Ok(Some(header_info)) = self.context.chainview.get_block(block_hash) else {
                         break;
                     };
 
@@ -874,16 +649,15 @@ impl Peer {
                 let version = NetworkMessage::Version(VersionMessage {
                     version: 70001,
                     services: ServiceFlags::NETWORK_LIMITED
-                                | ServiceFlags::NETWORK
-                                | ServiceFlags::WITNESS
-                                | ServiceFlags::from(1 << 24)  // UTREEXO
-                                | ServiceFlags::from(1 << 25), // UTREEXO_BLOCK_FILTERS
+                        | ServiceFlags::NETWORK
+                        | ServiceFlags::WITNESS
+                        | ServiceFlags::from(1 << 24), // UTREEXO
                     timestamp: version.timestamp + 1,
                     receiver: version.sender.clone(),
                     sender: version.receiver.clone(),
                     nonce: version.nonce + 100,
-                    user_agent: "/rustreexo:0.1.0/bridge:0.1.0".to_string(),
-                    start_height: self.proof_index.load_height() as i32,
+                    user_agent: "/bridge:0.1.0/".to_string(),
+                    start_height: self.context.proof_index.load_height() as i32,
                     relay: false,
                 });
 
@@ -896,7 +670,7 @@ impl Peer {
 
             NetworkMessage::GetCFilters(req) => {
                 if req.filter_type == FILTER_TYPE_UTREEXO {
-                    let Ok(Some(acc)) = self.chainview.get_acc(req.stop_hash) else {
+                    let Ok(Some(acc)) = self.context.chainview.get_acc(req.stop_hash) else {
                         // if this block is not in the chainview, ignore the request
                         return Ok(());
                     };

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -390,6 +390,10 @@ impl<LeafStorage: LeafCache, Storage: BlockStorage> Prover<LeafStorage, Storage>
         }
 
         let height = self.rpc.get_block_count()? as u32;
+        if height == self.height {
+            self.ibd = false; // we'll flip it once, and keep it false for the rest of the time
+            return Ok(());
+        }
 
         if height > self.height {
             self.prove_range(self.height + 1, height)?;
@@ -398,7 +402,6 @@ impl<LeafStorage: LeafCache, Storage: BlockStorage> Prover<LeafStorage, Storage>
                 .expect("could not save the acc to disk");
             self.storage.update_height(height as usize);
         }
-        self.ibd = false; // we'll flip it once, and keep it false for the rest of the time
         *last_tip_update = std::time::Instant::now();
         Ok(())
     }


### PR DESCRIPTION
Before this commit, we had one reactor that sent jobs to workers, but this system creates a very complex flow, with sockets being sent to more than one worker at a time, due to duplicated socket events.

This commit takes an approach closer to tokio's, where each worker has its own reactor. The global reactor now is an acceptor, it accepts new connections and send them to a random worker, load-balancing them.