### PR TITLE
Added cli option to bitcoin dir with backward compatibility

### DIFF
--- a/src/bitcoin_bridge.rs
+++ b/src/bitcoin_bridge.rs
@@ -93,7 +93,7 @@ pub fn run_bridge() -> anyhow::Result<()> {
     // The prover needs some way to pull blocks from a trusted source, we can use anything
     // implementing the [Blockchain] trait, for example a bitcoin core node or an esplora
     // instance.
-    let client = get_chain_provider()?;
+    let client = get_chain_provider(cli_options.bitcoin_datadir.as_deref())?;
 
     // Create a prover, this module will download blocks from the bitcoin core
     // node and save them to disk. It will also create proofs for the blocks

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,4 +34,9 @@ pub struct CliArgs {
     /// The network we are operating on
     #[clap(long, short = 'n', default_value = "bitcoin")]
     pub network: Network,
+
+    /// The Bitcoin data directory path. This is used to locate the Bitcoin Core cookie file
+    /// for RPC authentication.
+    #[clap(long)]
+    pub bitcoin_datadir: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn init_logger(log_file: Option<&str>, log_level: log::LevelFilter, log_to_term:
     let _ = simplelog::CombinedLogger::init(loggers);
 }
 
-fn get_chain_provider() -> Result<Box<dyn Blockchain>> {
+fn get_chain_provider(bitcoin_datadir: Option<&str>) -> Result<Box<dyn Blockchain>> {
     #[cfg(feature = "esplora")]
     if let Ok(esplora_url) = env::var("ESPLORA_URL") {
         return Ok(Box::new(esplora::EsploraBlockchain::new(esplora_url)));
@@ -131,9 +131,12 @@ fn get_chain_provider() -> Result<Box<dyn Blockchain>> {
     }
     // fallback to cookie auth. This is the default for core, but discouraged for security reasons
     let cookie = env::var("BITCOIN_CORE_COOKIE_FILE").unwrap_or_else(|_| {
-        env::var("HOME")
-            .map(|home| format!("{}/.bitcoin/.cookie", home))
-            .expect("Failed to find $HOME")
+        if let Some(datadir) = bitcoin_datadir {
+            format!("{}/.cookie", datadir)
+        } else {
+            let home = env::var("HOME").expect("Failed to find $HOME");
+            format!("{}/.bitcoin/.cookie", home)
+        }
     });
     info!("Using cookie file at {}", cookie);
     let client = Client::new(&rpc_url, Auth::CookieFile(cookie.clone().into()));

--- a/src/shinigami_bridge.rs
+++ b/src/shinigami_bridge.rs
@@ -80,7 +80,7 @@ pub fn run_bridge() -> anyhow::Result<()> {
     // The prover needs some way to pull blocks from a trusted source, we can use anything
     // implementing the [Blockchain] trait, for example a bitcoin core node or an esplora
     // instance.
-    let client = get_chain_provider()?;
+    let client = get_chain_provider(cli_options.bitcoin_datadir.as_deref())?;
 
     // Create a prover, this module will download blocks from the bitcoin core
     // node and save them to disk. It will also create proofs for the blocks


### PR DESCRIPTION
Here is what i get : 

<img width="1487" height="158" alt="image" src="https://github.com/user-attachments/assets/1d164362-9615-4f71-886b-da3a912ee550" />

Implementation is backward compatible and CLI option is properly exposed.

Fix: #22 